### PR TITLE
refactor: atomic sync of logseq-cli and desktop app

### DIFF
--- a/.github/workflows/flake-update.yml
+++ b/.github/workflows/flake-update.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   update:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -154,23 +154,15 @@ jobs:
             --notes "Automated nightly build for commit [${rev_short}](https://github.com/logseq/logseq/commit/${rev})." \
             --target main
 
-      - name: Render manifest
-        run: |
-          tag="nightly-${{ needs.build.outputs.datestring }}"
-          published=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          asset_url="https://github.com/${{ github.repository }}/releases/download/${tag}/logseq-linux-x64-${{ needs.build.outputs.version }}.tar.gz"
-          printf '%s\n' \
-            '{' \
-            "  \"tag\": \"$tag\"," \
-            "  \"publishedAt\": \"$published\"," \
-            "  \"assetUrl\": \"$asset_url\"," \
-            "  \"assetSha256\": \"${{ needs.build.outputs.hash }}\"," \
-            "  \"logseqRev\": \"${{ needs.build.outputs.revision }}\"," \
-            "  \"logseqVersion\": \"${{ needs.build.outputs.version }}\"" \
-            '}' > manifest.json
-
-      - name: Update manifest file
-        run: mv manifest.json data/logseq-nightly.json
+      - name: Update nightly manifest and CLI hashes
+        env:
+          LOGSEQ_REV: ${{ needs.build.outputs.revision }}
+          LOGSEQ_VERSION: ${{ needs.build.outputs.version }}
+          ASSET_URL: >-
+            https://github.com/${{ github.repository }}/releases/download/nightly-${{ needs.build.outputs.datestring }}/logseq-linux-x64-${{ needs.build.outputs.version }}.tar.gz
+          ASSET_HASH: ${{ needs.build.outputs.hash }}
+          NIGHTLY_TAG: nightly-${{ needs.build.outputs.datestring }}
+        run: bash scripts/update-nightly.sh
 
       - name: Configure git
         run: |
@@ -180,9 +172,9 @@ jobs:
       - name: Format repository
         run: nix fmt
 
-      - name: Commit manifest update
+      - name: Commit nightly update
         run: |
-          if git status --short | grep -q data/logseq-nightly.json; then
+          if ! git diff --quiet -- data/logseq-nightly.json; then
             git add data/logseq-nightly.json
             git commit -m "chore: bump nightly manifest"
             git push
@@ -194,3 +186,4 @@ jobs:
         run: |
           nix flake check
           nix build .#logseq
+          nix build .#logseq-cli

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.value }}
       revision: ${{ steps.revision.outputs.rev }}
@@ -124,7 +124,7 @@ jobs:
             logseq-src/static/out/VERSION
 
   publish-release:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: build
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   validate:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,7 +18,7 @@ jobs:
             accept-flake-config = true
 
       - name: Check formatting
-        run: nix fmt -- --check .
+        run: nix fmt -- --ci
 
       - name: Run nix flake check
         run: nix flake check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     hooks:
       - id: nixfmt-rfc-style
         name: nixfmt (rfc-style)
-        entry: nix fmt .
+        entry: nix fmt
         language: system
         pass_filenames: false
       - id: deadnix

--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ The desktop app is built from the latest upstream commit via this repository's
 [GitHub Actions nightly build](.github/workflows/nightly.yml), wrapped in an
 opinionated FHS environment tuned for Electron workloads.
 
-The CLI is built from the official `@logseq/cli` source, providing offline
-access to DB graphs for querying, exporting, and running an MCP server without
-the desktop app.
+The CLI is built from the official `@logseq/cli` source, pinned to the same
+upstream commit as the desktop app via the shared
+[`data/logseq-nightly.json`](data/logseq-nightly.json) manifest. It provides
+offline access to DB graphs for querying, exporting, and running an MCP server
+without the desktop app.
 
 > [!WARNING]
 > This flake currently packages only Linux x86_64 builds. Additional platforms can be added if there is demand.
@@ -177,8 +179,9 @@ that NVIDIA's proprietary stack expects (`__NV_PRIME_RENDER_OFFLOAD`,
 
 ## CI pipelines
 
-- [Nightly build](.github/workflows/nightly.yml) keeps `data/logseq-nightly.json` in sync with the latest upstream commit and publishes the tarball consumed by this flake.
-- [Validate](.github/workflows/validate.yml) runs formatting and static checks on every push/PR to keep the flake tidy.
+- [Nightly build](.github/workflows/nightly.yml) builds Logseq from upstream `master`, publishes the tarball, and runs [`scripts/update-nightly.sh`](scripts/update-nightly.sh) to compute all manifest fields (desktop hash, CLI source hash, yarn deps hash, CLI version) into `data/logseq-nightly.json`.
+- [Validate](.github/workflows/validate.yml) runs formatting and static checks on every push/PR.
+- [Flake Update](.github/workflows/flake-update.yml) updates `flake.lock` weekly (Sunday cron).
 
 ## License
 

--- a/data/logseq-nightly.json
+++ b/data/logseq-nightly.json
@@ -1,11 +1,11 @@
 {
   "tag": "nightly-20260127",
-  "publishedAt": "2026-01-27T02:36:08Z",
+  "publishedAt": "2026-01-27T09:46:39Z",
   "assetUrl": "https://github.com/Bad3r/nix-logseq-git-flake/releases/download/nightly-20260127/logseq-linux-x64-2.0.0-alpha+nightly.20260127.tar.gz",
-  "assetSha256": "sha256-70vPmojW7ESILGI2zRdNG2DGtFSk64A0PPvo7GhV7UE=",
-  "logseqRev": "23d6f1538a514b7385a3b1ac5ef47888f3ee585a",
+  "assetSha256": "sha256-VjQzsc65O1eED3L8sHgReL39Oj7c2nN8PEuNo8q5DY4=",
+  "logseqRev": "0d4ce6a6159d7712765e7d704908969b67bdf5c5",
   "logseqVersion": "2.0.0-alpha+nightly.20260127",
-  "cliSrcHash": "sha256-2qwleKVmWhqMvtJOT+dWFq1MoLpxaZ+wIvVGL2jShaw=",
+  "cliSrcHash": "sha256-dR6oV+WbRAmWjKeNA9FV4TuV6WpbgFbJLihsQZTSw3k=",
   "cliYarnDepsHash": "sha256-bhhDJQV62RSW2LsSk8D5eRZv/FLhn1Co3Aqn+ZKVgWs=",
   "cliVersion": "0.4.2"
 }

--- a/data/logseq-nightly.json
+++ b/data/logseq-nightly.json
@@ -4,5 +4,8 @@
   "assetUrl": "https://github.com/Bad3r/nix-logseq-git-flake/releases/download/nightly-20260127/logseq-linux-x64-2.0.0-alpha+nightly.20260127.tar.gz",
   "assetSha256": "sha256-70vPmojW7ESILGI2zRdNG2DGtFSk64A0PPvo7GhV7UE=",
   "logseqRev": "23d6f1538a514b7385a3b1ac5ef47888f3ee585a",
-  "logseqVersion": "2.0.0-alpha+nightly.20260127"
+  "logseqVersion": "2.0.0-alpha+nightly.20260127",
+  "cliSrcHash": "sha256-2qwleKVmWhqMvtJOT+dWFq1MoLpxaZ+wIvVGL2jShaw=",
+  "cliYarnDepsHash": "sha256-bhhDJQV62RSW2LsSk8D5eRZv/FLhn1Co3Aqn+ZKVgWs=",
+  "cliVersion": "0.4.2"
 }

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1769018530,
-        "narHash": "sha256-MJ27Cy2NtBEV5tsK+YraYr2g851f3Fl1LpNHDzDX15c=",
+        "lastModified": 1769170682,
+        "narHash": "sha256-oMmN1lVQU0F0W2k6OI3bgdzp2YOHWYUAw79qzDSjenU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "88d3861acdd3d2f0e361767018218e51810df8a1",
+        "rev": "c5296fdd05cfa2c187990dd909864da9658df755",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -110,7 +110,14 @@
           fi
           exec ${logseqFhs}/bin/logseq-fhs "$@"
         '';
-        cli = pkgs.callPackage ./lib/cli.nix { };
+        cli = pkgs.callPackage ./lib/cli.nix {
+          inherit (manifest)
+            logseqRev
+            cliSrcHash
+            cliVersion
+            cliYarnDepsHash
+            ;
+        };
         package = pkgs.stdenv.mkDerivation {
           pname = "logseq";
           version = manifest.logseqVersion;
@@ -161,7 +168,7 @@
             touch $out
           '';
         };
-        formatter = pkgs.nixfmt;
+        formatter = pkgs.nixfmt-tree;
       }
     );
 }

--- a/lib/cli.nix
+++ b/lib/cli.nix
@@ -13,23 +13,28 @@
   gcc,
   pkg-config,
   sqlite,
+  # Manifest-driven parameters (passed from flake.nix)
+  logseqRev,
+  cliSrcHash,
+  cliVersion,
+  cliYarnDepsHash,
 }:
 
 let
-  version = "0.4.2";
+  version = cliVersion;
 
   src = fetchFromGitHub {
     owner = "logseq";
     repo = "logseq";
-    rev = "master";
-    hash = "sha256-2qwleKVmWhqMvtJOT+dWFq1MoLpxaZ+wIvVGL2jShaw=";
+    rev = logseqRev;
+    hash = cliSrcHash;
   };
 
   cliOfflineCache = fetchYarnDeps {
     name = "logseq-cli-yarn-deps";
     inherit src;
     postPatch = "cd deps/cli";
-    hash = "sha256-bhhDJQV62RSW2LsSk8D5eRZv/FLhn1Co3Aqn+ZKVgWs=";
+    hash = cliYarnDepsHash;
   };
 
   # Build the CLI from offline yarn cache

--- a/lib/loadManifest.nix
+++ b/lib/loadManifest.nix
@@ -16,9 +16,15 @@ let
   ];
   missing = lib.filter (key: !hasAttr key parsed) requiredKeys;
   validateHash =
-    key:
-    throwIf (!hasPrefix "sha256-" parsed.${key}) "Manifest ${key} must begin with sha256- (Nix SRI).";
+    acc: key:
+    throwIf (
+      !hasPrefix "sha256-" parsed.${key}
+    ) "Manifest ${key} must begin with sha256- (Nix SRI)." acc;
 in
 throwIf (missing != [ ]) "Manifest missing required keys: ${concatStringsSep ", " missing}" (
-  validateHash "assetSha256" (validateHash "cliSrcHash" (validateHash "cliYarnDepsHash" parsed))
+  builtins.foldl' validateHash parsed [
+    "assetSha256"
+    "cliSrcHash"
+    "cliYarnDepsHash"
+  ]
 )

--- a/lib/loadManifest.nix
+++ b/lib/loadManifest.nix
@@ -10,11 +10,15 @@ let
     "assetSha256"
     "logseqRev"
     "logseqVersion"
+    "cliSrcHash"
+    "cliYarnDepsHash"
+    "cliVersion"
   ];
   missing = lib.filter (key: !hasAttr key parsed) requiredKeys;
+  validateHash =
+    key:
+    throwIf (!hasPrefix "sha256-" parsed.${key}) "Manifest ${key} must begin with sha256- (Nix SRI).";
 in
 throwIf (missing != [ ]) "Manifest missing required keys: ${concatStringsSep ", " missing}" (
-  throwIf (
-    !hasPrefix "sha256-" parsed.assetSha256
-  ) "Manifest assetSha256 must begin with sha256- (Nix base32)." parsed
+  validateHash "assetSha256" (validateHash "cliSrcHash" (validateHash "cliYarnDepsHash" parsed))
 )

--- a/scripts/update-nightly.sh
+++ b/scripts/update-nightly.sh
@@ -29,7 +29,7 @@ echo "::endgroup::"
 
 # ── Phase 2: Compute CLI source hash ────────────────────────────────
 echo "::group::Phase 2: Compute CLI source hash (nix-prefetch-github)"
-CLI_SRC_HASH=$(nix shell nixpkgs#nix-prefetch-github -c \
+CLI_SRC_HASH=$(nix shell nixpkgs#nix-prefetch-github nixpkgs#nix-prefetch-git -c \
   nix-prefetch-github logseq logseq --rev "$LOGSEQ_REV" --json | jq -r '.hash')
 echo "  cliSrcHash=$CLI_SRC_HASH"
 echo "::endgroup::"

--- a/scripts/update-nightly.sh
+++ b/scripts/update-nightly.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# update-nightly.sh — Compute all hashes and write data/logseq-nightly.json
+#
+# Required environment variables:
+#   LOGSEQ_REV      — upstream commit SHA
+#   LOGSEQ_VERSION  — version string (e.g. 2.0.0-alpha+nightly.20260127)
+#   ASSET_URL       — tarball download URL
+#   ASSET_HASH      — SRI hash of the desktop tarball
+#   NIGHTLY_TAG     — release tag (e.g. nightly-20260127)
+
+set -euo pipefail
+
+MANIFEST="data/logseq-nightly.json"
+
+# ── Phase 1: Validate inputs ────────────────────────────────────────
+echo "::group::Phase 1: Validate inputs"
+: "${LOGSEQ_REV:?must be set}"
+: "${LOGSEQ_VERSION:?must be set}"
+: "${ASSET_URL:?must be set}"
+: "${ASSET_HASH:?must be set}"
+: "${NIGHTLY_TAG:?must be set}"
+PUBLISHED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+echo "All inputs validated"
+echo "  LOGSEQ_REV=$LOGSEQ_REV"
+echo "  LOGSEQ_VERSION=$LOGSEQ_VERSION"
+echo "  NIGHTLY_TAG=$NIGHTLY_TAG"
+echo "  PUBLISHED_AT=$PUBLISHED_AT"
+echo "::endgroup::"
+
+# ── Phase 2: Compute CLI source hash ────────────────────────────────
+echo "::group::Phase 2: Compute CLI source hash (nix-prefetch-github)"
+CLI_SRC_HASH=$(nix shell nixpkgs#nix-prefetch-github -c \
+  nix-prefetch-github logseq logseq --rev "$LOGSEQ_REV" --json | jq -r '.hash')
+echo "  cliSrcHash=$CLI_SRC_HASH"
+echo "::endgroup::"
+
+# ── Phase 3: Fetch CLI version from upstream ─────────────────────────
+echo "::group::Phase 3: Fetch CLI version"
+CLI_VERSION=$(curl -fsSL \
+  "https://raw.githubusercontent.com/logseq/logseq/${LOGSEQ_REV}/deps/cli/package.json" \
+  | jq -r '.version')
+echo "  cliVersion=$CLI_VERSION"
+echo "::endgroup::"
+
+# ── Phase 4: Write manifest with placeholder yarn hash ──────────────
+echo "::group::Phase 4: Write manifest (placeholder yarn hash)"
+PLACEHOLDER="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+jq -n \
+  --arg tag "$NIGHTLY_TAG" \
+  --arg publishedAt "$PUBLISHED_AT" \
+  --arg assetUrl "$ASSET_URL" \
+  --arg assetSha256 "$ASSET_HASH" \
+  --arg logseqRev "$LOGSEQ_REV" \
+  --arg logseqVersion "$LOGSEQ_VERSION" \
+  --arg cliSrcHash "$CLI_SRC_HASH" \
+  --arg cliYarnDepsHash "$PLACEHOLDER" \
+  --arg cliVersion "$CLI_VERSION" \
+  '{
+    tag: $tag,
+    publishedAt: $publishedAt,
+    assetUrl: $assetUrl,
+    assetSha256: $assetSha256,
+    logseqRev: $logseqRev,
+    logseqVersion: $logseqVersion,
+    cliSrcHash: $cliSrcHash,
+    cliYarnDepsHash: $cliYarnDepsHash,
+    cliVersion: $cliVersion
+  }' > "$MANIFEST"
+echo "  Wrote $MANIFEST with placeholder cliYarnDepsHash"
+echo "::endgroup::"
+
+# ── Phase 5: Double-build to extract yarn deps hash ─────────────────
+echo "::group::Phase 5: Double-build for yarn deps hash"
+set +e
+BUILD_OUTPUT=$(nix build .#logseq-cli 2>&1)
+BUILD_EXIT=$?
+set -e
+
+if [ "$BUILD_EXIT" -eq 0 ]; then
+  echo "ERROR: nix build succeeded with placeholder hash — this should not happen" >&2
+  exit 1
+fi
+
+# ── Phase 6: Extract real hash from error output ─────────────────────
+YARN_HASH=$(echo "$BUILD_OUTPUT" | sed -n 's/.*got: *\(sha256-[A-Za-z0-9+/=]\{1,\}\).*/\1/p' | head -1)
+
+if [ -z "$YARN_HASH" ]; then
+  echo "ERROR: Could not extract yarn deps hash from build output" >&2
+  echo "Full build output:" >&2
+  echo "$BUILD_OUTPUT" >&2
+  exit 1
+fi
+echo "  cliYarnDepsHash=$YARN_HASH"
+echo "::endgroup::"
+
+# ── Phase 7: Rewrite manifest with real yarn hash ────────────────────
+echo "::group::Phase 7: Finalize manifest"
+jq --arg hash "$YARN_HASH" '.cliYarnDepsHash = $hash' "$MANIFEST" > "${MANIFEST}.tmp"
+mv "${MANIFEST}.tmp" "$MANIFEST"
+echo "  Updated $MANIFEST with real cliYarnDepsHash"
+echo "::endgroup::"
+
+# ── Summary ──────────────────────────────────────────────────────────
+echo ""
+echo "=== Manifest updated ==="
+echo "  tag:              $NIGHTLY_TAG"
+echo "  logseqRev:        $LOGSEQ_REV"
+echo "  logseqVersion:    $LOGSEQ_VERSION"
+echo "  assetSha256:      $ASSET_HASH"
+echo "  cliSrcHash:       $CLI_SRC_HASH"
+echo "  cliYarnDepsHash:  $YARN_HASH"
+echo "  cliVersion:       $CLI_VERSION"

--- a/scripts/update-nightly.sh
+++ b/scripts/update-nightly.sh
@@ -82,7 +82,7 @@ if [ "$BUILD_EXIT" -eq 0 ]; then
 fi
 
 # ── Phase 6: Extract real hash from error output ─────────────────────
-YARN_HASH=$(echo "$BUILD_OUTPUT" | sed -n 's/.*got: *\(sha256-[A-Za-z0-9+/=]\{1,\}\).*/\1/p' | head -1)
+YARN_HASH=$(echo "$BUILD_OUTPUT" | sed -n 's/.*got: *\(sha256-[A-Za-z0-9+/=]\{44\}\).*/\1/p' | head -1)
 
 if [ -z "$YARN_HASH" ]; then
   echo "ERROR: Could not extract yarn deps hash from build output" >&2


### PR DESCRIPTION
## Summary
- Unify CLI and desktop packages under a single manifest so both derive from the same upstream commit
- Parameterize lib/cli.nix — remove hardcoded rev, version, and hashes; accept them from the manifest via callPackage
- Extend lib/loadManifest.nix with 3 new required keys and a validateHash helper for SRI validation
- Add scripts/update-nightly.sh to compute all CLI hashes via a double-build pattern
- Replace inline manifest rendering in nightly.yml with the new script
- Switch formatter to nixfmt-tree and update CI to use ubuntu-latest

## Test plan
- [x] nix flake check passes
- [x] nix build .#logseq and .#logseq-cli succeed
- [x] All pre-commit hooks pass
- [x] All 3 CI workflows pass end-to-end