### PR TITLE
chore(ci): push nightly outputs to Cachix

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -182,8 +182,14 @@ jobs:
       - name: Validate flake
         run: |
           nix flake check
-          nix build .#logseq
-          nix build .#logseq-cli
+
+      - name: Push Nix store paths to Cachix
+        env:
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        run: |
+          set -euo pipefail
+          nix shell nixpkgs#cachix -c bash -c \
+            'nix build --no-link --print-out-paths .#logseq .#logseq-cli .#default | cachix push nix-logseq-git-flake'
 
       - name: Commit nightly update
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -148,6 +148,12 @@ jobs:
           extra_nix_config: |
             accept-flake-config = true
 
+      - name: Setup Cachix
+        uses: cachix/cachix-action@v15
+        with:
+          name: nix-logseq-git-flake
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
       - name: Publish GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -182,14 +188,6 @@ jobs:
       - name: Validate flake
         run: |
           nix flake check
-
-      - name: Push Nix store paths to Cachix
-        env:
-          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
-        run: |
-          set -euo pipefail
-          nix shell nixpkgs#cachix -c bash -c \
-            'nix build --no-link --print-out-paths .#logseq .#logseq-cli .#default | cachix push nix-logseq-git-flake'
 
       - name: Commit nightly update
         run: |

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,15 @@
     };
   };
 
+  nixConfig = {
+    extra-substituters = [
+      "https://nix-logseq-git-flake.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "nix-logseq-git-flake.cachix.org-1:DSBNW07PSRyCvS926tpIWahb53OIydwwZhsP6LhJNZo="
+    ];
+  };
+
   outputs =
     {
       self,


### PR DESCRIPTION
Adds Cachix caching support for nix-logseq-git-flake.

- flake.nix: add nixConfig (extra-substituters + extra-trusted-public-keys) for nix-logseq-git-flake.cachix.org
- nightly.yml: configure Cachix via cachix/cachix-action@v15 (authToken: CACHIX_AUTH_TOKEN) so store paths built during the job are pushed automatically
