### PR TITLE
fix(cli): suppress pnpm auto-switch via env var

### DIFF
--- a/lib/cli.nix
+++ b/lib/cli.nix
@@ -37,15 +37,16 @@ let
     pnpm = pnpm_10;
     fetcherVersion = 3;
     hash = cliPnpmDepsHash;
-    # nixpkgs fetchPnpmDeps disables pnpm's auto-switch via `pushd ..; pnpm
-    # config set ...`, but `..` is still inside the upstream repo, whose root
-    # package.json pins `packageManager: pnpm@10.33.0`. pnpm walks up, finds it,
-    # and tries to self-install before applying the setting. Place an .npmrc at
-    # the pushd target so the setting is read first.
-    postPatch = ''
-      chmod +w ..
-      echo "manage-package-manager-versions=false" >> ../.npmrc
-    '';
+    # Both source/package.json and source/deps/cli/package.json pin
+    # `packageManager: pnpm@<exact version>`. When the nixpkgs-provided pnpm
+    # doesn't match exactly (e.g. patch-level bump), pnpm self-installs the
+    # requested version into $HOME/.local/share before running any command —
+    # failing in the build sandbox. fetchPnpmDeps tries to suppress this with
+    # `pushd ..; pnpm config set manage-package-manager-versions false`, but
+    # that runs from `source/deps/`, where pnpm walks up to `source/package.json`
+    # and triggers the auto-switch *during* the config-set itself. The env var
+    # is consulted before any package.json walk, so it short-circuits cleanly.
+    env.npm_config_manage_package_manager_versions = "false";
   };
 
   # Build the CLI from an offline pnpm store.
@@ -71,7 +72,12 @@ let
     pnpmDeps = cliPnpmDeps;
     pnpmRoot = "cli";
 
-    env.npm_config_nodedir = nodejs_22;
+    env = {
+      npm_config_nodedir = nodejs_22;
+      # Same rationale as on cliPnpmDeps: pin packageManager mismatch would
+      # otherwise trigger pnpm's auto-switch during `pnpm rebuild`.
+      npm_config_manage_package_manager_versions = "false";
+    };
 
     buildPhase = ''
       runHook preBuild


### PR DESCRIPTION
## Summary

Replaces the `postPatch` workaround on `cliPnpmDeps` with `env.npm_config_manage_package_manager_versions = "false"`. The env var is consulted before any `package.json` walk-up, so the auto-switch is short-circuited regardless of which sub-tree carries the `packageManager` pin.

## Why the previous fix stopped working

The previous workaround dropped `manage-package-manager-versions=false` into `source/deps/.npmrc`, expecting pnpm to read it during fetchPnpmDeps's `pushd ..; pnpm config set ...` step. That worked while only the root `package.json` carried the `packageManager` field, but upstream now also pins it in `deps/cli/package.json`. With a closer `package.json` carrying the pin, pnpm's auto-switch decision happens before project-level npmrc lookup, so the parent `.npmrc` is ignored. Whenever the nixpkgs-provided pnpm drifts even by patch level, pnpm tries to self-install into `$HOME/.local/share/pnpm/.tools/...` and fails inside the build sandbox with `ENOENT`.

The env var is read up front by pnpm's config layer, so it always wins.

The same env var is also set on `cliBuilt` for symmetry, in case `pnpm rebuild` ever runs before `pnpmConfigHook` writes the user-level setting.

## Test plan

- [x] `nix build .#logseq-cli` succeeds (verified locally; cliPnpmDeps fixed-output hash unchanged → no manifest bump needed)
- [x] `nix build .#checks.x86_64-linux.logseq-cli` passes
- [x] `nix flake check` clean
- [x] Reproduced the original failure in a sandbox-equivalent test (pnpm@10.99.0 vs runtime 10.33.0) and confirmed the env-var fix prevents the auto-switch