### PR TITLE
fix(cli): populate vendor/src so nbb-logseq can resolve namespaces

### DIFF
--- a/data/logseq-nightly.json
+++ b/data/logseq-nightly.json
@@ -7,5 +7,6 @@
   "logseqVersion": "2.0.1-alpha+nightly.20260504",
   "cliSrcHash": "sha256-k7zTC22RhlDhKiLE9N7rjExx2VyQi7Dxj6T9taF/j34=",
   "cliPnpmDepsHash": "sha256-F6QwXe4/UIGjSMD1HUuLrk1VVfQSeRTmhw3tvQdk5Q8=",
+  "cliVendorHash": "sha256-giDA1VbI6Nikg8GdoNYAj1ITAoagB0ENZO1a3pwwY+o=",
   "cliVersion": "0.4.3"
 }

--- a/data/logseq-nightly.json
+++ b/data/logseq-nightly.json
@@ -7,6 +7,6 @@
   "logseqVersion": "2.0.1-alpha+nightly.20260504",
   "cliSrcHash": "sha256-k7zTC22RhlDhKiLE9N7rjExx2VyQi7Dxj6T9taF/j34=",
   "cliPnpmDepsHash": "sha256-F6QwXe4/UIGjSMD1HUuLrk1VVfQSeRTmhw3tvQdk5Q8=",
-  "cliVendorHash": "sha256-M0NVLD7ADqiGRUHxUNKyuS9VBtnwqE8IJbUORmMXPa8=",
+  "cliVendorHash": "sha256-qFORLjmFSP9/yN7RjNOZ2o3R/5B+igeMQmTFN5eYnf0=",
   "cliVersion": "0.4.3"
 }

--- a/data/logseq-nightly.json
+++ b/data/logseq-nightly.json
@@ -7,6 +7,6 @@
   "logseqVersion": "2.0.1-alpha+nightly.20260504",
   "cliSrcHash": "sha256-k7zTC22RhlDhKiLE9N7rjExx2VyQi7Dxj6T9taF/j34=",
   "cliPnpmDepsHash": "sha256-F6QwXe4/UIGjSMD1HUuLrk1VVfQSeRTmhw3tvQdk5Q8=",
-  "cliVendorHash": "sha256-giDA1VbI6Nikg8GdoNYAj1ITAoagB0ENZO1a3pwwY+o=",
+  "cliVendorHash": "sha256-M0NVLD7ADqiGRUHxUNKyuS9VBtnwqE8IJbUORmMXPa8=",
   "cliVersion": "0.4.3"
 }

--- a/flake.nix
+++ b/flake.nix
@@ -288,6 +288,17 @@
           # namespace (the regression class fixed in PR #21) crashes here
           # on the first loadFile, so passing both probes is a strong
           # signal that the FOD copy still produces a working tree.
+          #
+          # Both probes assert on stable upstream substrings (`Usage:`,
+          # `mcp-server`, `database version`). If upstream rewords any of
+          # these, the grep fails closed — that's the right direction for
+          # a regression guard, and the failing line in the build log
+          # points at the exact substring to update.
+          #
+          # Probe order matters: probe 1 (`--help`) populates
+          # `NBB_CACHE_DIR` before probe 2 (`list`) reuses it. That keeps
+          # probe 2 fast at the cost of not independently verifying empty-
+          # cache population — probe 1 covers that case implicitly.
           logseq-cli-help = pkgs.runCommand "logseq-cli-help-check" { } ''
             export HOME=$TMPDIR
             export XDG_CACHE_HOME=$TMPDIR/cache

--- a/flake.nix
+++ b/flake.nix
@@ -283,6 +283,29 @@
             ${pkgs.coreutils}/bin/test -x ${cli}/bin/logseq-cli
             touch $out
           '';
+          # Runtime smoke test: invoking the CLI exercises nbb-logseq's
+          # classpath (cli/src + cli/vendor/src). Any missing vendor
+          # namespace (the regression class fixed in PR #21) crashes here
+          # on the first loadFile, so a passing `--help` is a strong
+          # signal that the FOD copy still produces a working tree.
+          logseq-cli-help = pkgs.runCommand "logseq-cli-help-check" { } ''
+            export HOME=$TMPDIR
+            export XDG_CACHE_HOME=$TMPDIR/cache
+            output=$(${cli}/bin/logseq-cli --help 2>&1)
+            status=$?
+            if [ "$status" -ne 0 ]; then
+              echo "logseq-cli --help exited $status" >&2
+              echo "$output" >&2
+              exit 1
+            fi
+            # `Usage:` and `mcp-server` are stable substrings of the help
+            # output produced by the upstream CLI; require both so a future
+            # silent fallthrough (e.g. nbb prints a stack trace but still
+            # exits 0) doesn't get rubber-stamped.
+            echo "$output" | ${pkgs.gnugrep}/bin/grep -q '^Usage:'
+            echo "$output" | ${pkgs.gnugrep}/bin/grep -q 'mcp-server'
+            touch $out
+          '';
           pre-commit-check = preCommit;
         };
         devShells =

--- a/flake.nix
+++ b/flake.nix
@@ -225,6 +225,7 @@
             cliSrcHash
             cliVersion
             cliPnpmDepsHash
+            cliVendorHash
             ;
         };
         logseqDesktop = pkgs.stdenv.mkDerivation {

--- a/flake.nix
+++ b/flake.nix
@@ -286,24 +286,41 @@
           # Runtime smoke test: invoking the CLI exercises nbb-logseq's
           # classpath (cli/src + cli/vendor/src). Any missing vendor
           # namespace (the regression class fixed in PR #21) crashes here
-          # on the first loadFile, so a passing `--help` is a strong
+          # on the first loadFile, so passing both probes is a strong
           # signal that the FOD copy still produces a working tree.
           logseq-cli-help = pkgs.runCommand "logseq-cli-help-check" { } ''
             export HOME=$TMPDIR
             export XDG_CACHE_HOME=$TMPDIR/cache
-            output=$(${cli}/bin/logseq-cli --help 2>&1)
-            status=$?
-            if [ "$status" -ne 0 ]; then
-              echo "logseq-cli --help exited $status" >&2
-              echo "$output" >&2
+
+            # Probe 1: --help exercises the help renderer's namespace.
+            help_output=$(${cli}/bin/logseq-cli --help 2>&1)
+            help_status=$?
+            if [ "$help_status" -ne 0 ]; then
+              echo "logseq-cli --help exited $help_status" >&2
+              echo "$help_output" >&2
               exit 1
             fi
             # `Usage:` and `mcp-server` are stable substrings of the help
             # output produced by the upstream CLI; require both so a future
             # silent fallthrough (e.g. nbb prints a stack trace but still
             # exits 0) doesn't get rubber-stamped.
-            echo "$output" | ${pkgs.gnugrep}/bin/grep -q '^Usage:'
-            echo "$output" | ${pkgs.gnugrep}/bin/grep -q 'mcp-server'
+            echo "$help_output" | ${pkgs.gnugrep}/bin/grep -q '^Usage:'
+            echo "$help_output" | ${pkgs.gnugrep}/bin/grep -q 'mcp-server'
+
+            # Probe 2: `list` against an empty HOME forces the
+            # graph-discovery namespace (the original regression site —
+            # `logseq.common.graph-dir`) to load. With no graphs present
+            # the CLI emits a stable warning string and exits 0; a missing
+            # vendor namespace would crash before reaching that point.
+            list_output=$(${cli}/bin/logseq-cli list 2>&1)
+            list_status=$?
+            if [ "$list_status" -ne 0 ]; then
+              echo "logseq-cli list exited $list_status" >&2
+              echo "$list_output" >&2
+              exit 1
+            fi
+            echo "$list_output" | ${pkgs.gnugrep}/bin/grep -qF 'database version'
+
             touch $out
           '';
           pre-commit-check = preCommit;

--- a/lib/cli.nix
+++ b/lib/cli.nix
@@ -61,8 +61,17 @@ let
   # `logseq.common.graph-dir` and friends.
   #
   # Implemented as a fixed-output derivation: `pnpm exec nbb-logseq -e
-  # :load-deps` fetches sha-pinned git/maven deps over the network. The output
-  # is just CLJS sources keyed by namespace, so the NAR hash is deterministic.
+  # :load-deps` fetches sha-pinned git/maven deps over the network. The
+  # `:load-deps` keyword itself is a no-op expression; nbb just has to
+  # bootstrap its dep graph before evaluating any `-e` form, and that
+  # bootstrap is what populates `.nbb/.cache/<hash>/nbb-deps/`. The output is
+  # CLJS sources keyed by namespace, so the NAR hash is deterministic.
+  #
+  # `babashka` is required at build time even though we never invoke `bb`
+  # directly: nbb-logseq's `nbb_deps.js` shells out to `bb uberjar` to pack
+  # the resolved deps before populating the cache. Removing it from
+  # nativeBuildInputs surfaces as `bb: not found` from execSync in the
+  # buildPhase log.
   cliVendor = stdenv.mkDerivation {
     pname = "logseq-cli-vendor";
     inherit version src;
@@ -108,13 +117,47 @@ let
       fi
       nbb_deps="''${cache_dirs[0]}nbb-deps"
 
-      mkdir -p $out
+      if [ ! -d "$nbb_deps" ]; then
+        echo "ERROR: missing $nbb_deps — upstream may have changed nbb-deps layout" >&2
+        exit 1
+      fi
+
+      # Copy every namespace subdir, not just upstream's current vendor
+      # allowlist. nbb's resolver may pull in new top-level deps in a future
+      # nightly (e.g. rewrite-clj); a hardcoded allowlist would silently drop
+      # them and re-trigger the namespace-resolution failure this FOD is
+      # meant to prevent. Loose top-level files like `data_readers.clj` /
+      # `data_readers.cljc` are intentionally skipped — they live at
+      # classpath root and Clojure auto-loads them, so vendoring them would
+      # alter runtime tagged-literal handling.
+      mkdir -p "$out"
+      shopt -s nullglob
+      copied=0
+      for entry in "$nbb_deps"/*/; do
+        name=$(basename "$entry")
+        cp -r "$entry" "$out/$name"
+        copied=$((copied + 1))
+      done
+      shopt -u nullglob
+      if [ "$copied" -eq 0 ]; then
+        echo "ERROR: $nbb_deps had no namespace subdirs — upstream nbb-deps layout may have changed" >&2
+        exit 1
+      fi
+
+      # Strip .git/ trees left behind by nbb's git-pinned deps. Their contents
+      # (pack files, refs) are not bit-stable across clones and would tank the
+      # FOD output hash even though the source files themselves are pinned.
+      find "$out" -name .git -type d -prune -exec rm -rf {} +
+
+      # Sanity check: upstream's `bb build:vendor-nbb-deps` always copies these
+      # four top-level namespaces into vendor/src. If any are missing, nbb's
+      # deps loader produced an unexpected layout and the rest of this build
+      # is suspect.
       for dir in logseq malli borkdude medley; do
-        if [ ! -d "$nbb_deps/$dir" ]; then
-          echo "ERROR: missing $nbb_deps/$dir — upstream may have changed nbb-deps layout" >&2
+        if [ ! -d "$out/$dir" ]; then
+          echo "ERROR: $out/$dir not found after copy — upstream nbb-deps layout may have changed" >&2
           exit 1
         fi
-        cp -r "$nbb_deps/$dir" "$out/$dir"
       done
 
       runHook postInstall

--- a/lib/cli.nix
+++ b/lib/cli.nix
@@ -122,43 +122,29 @@ let
         exit 1
       fi
 
-      # Copy every namespace subdir, not just upstream's current vendor
-      # allowlist. nbb's resolver may pull in new top-level deps in a future
-      # nightly (e.g. rewrite-clj); a hardcoded allowlist would silently drop
-      # them and re-trigger the namespace-resolution failure this FOD is
-      # meant to prevent. Loose top-level files like `data_readers.clj` /
-      # `data_readers.cljc` are intentionally skipped — they live at
-      # classpath root and Clojure auto-loads them, so vendoring them would
-      # alter runtime tagged-literal handling.
+      # Mirror upstream's `bb build:vendor-nbb-deps` allowlist exactly.
+      # These are the four namespace prefixes the CLI's runtime classpath
+      # actually requires (logseq sibling deps + malli + borkdude + medley);
+      # nbb's full `nbb-deps/` cache also contains transitive deps like
+      # `clj-kondo.exports/` that ship compiled JARs/classfiles, which add
+      # bytes we don't need and risk introducing FOD hash variance.
+      # Maintenance contract: if a future upstream nightly extends
+      # upstream's bb task copy list (currently in
+      # `deps/cli/bb.edn :: build:vendor-nbb-deps`), update this loop and
+      # `cliVendorHash` together.
       mkdir -p "$out"
-      shopt -s nullglob
-      copied=0
-      for entry in "$nbb_deps"/*/; do
-        name=$(basename "$entry")
-        cp -r "$entry" "$out/$name"
-        copied=$((copied + 1))
+      for dir in logseq malli borkdude medley; do
+        if [ ! -d "$nbb_deps/$dir" ]; then
+          echo "ERROR: missing $nbb_deps/$dir — upstream may have changed nbb-deps layout" >&2
+          exit 1
+        fi
+        cp -r "$nbb_deps/$dir" "$out/$dir"
       done
-      shopt -u nullglob
-      if [ "$copied" -eq 0 ]; then
-        echo "ERROR: $nbb_deps had no namespace subdirs — upstream nbb-deps layout may have changed" >&2
-        exit 1
-      fi
 
       # Strip .git/ trees left behind by nbb's git-pinned deps. Their contents
       # (pack files, refs) are not bit-stable across clones and would tank the
       # FOD output hash even though the source files themselves are pinned.
       find "$out" -name .git -type d -prune -exec rm -rf {} +
-
-      # Sanity check: upstream's `bb build:vendor-nbb-deps` always copies these
-      # four top-level namespaces into vendor/src. If any are missing, nbb's
-      # deps loader produced an unexpected layout and the rest of this build
-      # is suspect.
-      for dir in logseq malli borkdude medley; do
-        if [ ! -d "$out/$dir" ]; then
-          echo "ERROR: $out/$dir not found after copy — upstream nbb-deps layout may have changed" >&2
-          exit 1
-        fi
-      done
 
       runHook postInstall
     '';

--- a/lib/cli.nix
+++ b/lib/cli.nix
@@ -279,6 +279,16 @@ stdenv.mkDerivation {
     chmod +x $out/bin/logseq-cli
   '';
 
+  # Expose the FODs so `scripts/update-nightly.sh` can target them
+  # individually (`nix build .#logseq-cli.cliPnpmDeps` and
+  # `.cliVendor`) instead of building the full CLI just to surface a
+  # placeholder hash mismatch. Building only one FOD at a time also
+  # rules out any parallel-build interleaving in the hash-extraction
+  # `sed` even when `--max-jobs` > 1.
+  passthru = {
+    inherit cliPnpmDeps cliVendor;
+  };
+
   meta = {
     description = "Logseq CLI for DB graphs - MCP server and graph management";
     homepage = "https://github.com/logseq/logseq/tree/master/deps/cli";

--- a/lib/cli.nix
+++ b/lib/cli.nix
@@ -6,6 +6,9 @@
   fetchFromGitHub,
   fetchPnpmDeps,
   writeShellScript,
+  babashka,
+  cacert,
+  git,
   nodejs_22,
   pnpm_10,
   pnpmConfigHook,
@@ -19,6 +22,7 @@
   cliSrcHash,
   cliVersion,
   cliPnpmDepsHash,
+  cliVendorHash,
 }:
 
 let
@@ -47,6 +51,76 @@ let
     # and triggers the auto-switch *during* the config-set itself. The env var
     # is consulted before any package.json walk, so it short-circuits cleanly.
     env.npm_config_manage_package_manager_versions = "false";
+  };
+
+  # Replicate upstream's `bb build:vendor-nbb-deps` task. nbb-logseq is an
+  # interpreter, not a compiler, so the CLI needs the source of every
+  # transitively-required namespace at runtime. Upstream collects them under
+  # deps/cli/vendor/src/ before publishing to npm; we have to do the same
+  # before the runtime classpath (cli/src + cli/vendor/src) can resolve
+  # `logseq.common.graph-dir` and friends.
+  #
+  # Implemented as a fixed-output derivation: `pnpm exec nbb-logseq -e
+  # :load-deps` fetches sha-pinned git/maven deps over the network. The output
+  # is just CLJS sources keyed by namespace, so the NAR hash is deterministic.
+  cliVendor = stdenv.mkDerivation {
+    pname = "logseq-cli-vendor";
+    inherit version src;
+    sourceRoot = "${src.name}/deps";
+
+    nativeBuildInputs = [
+      babashka
+      cacert
+      git
+      nodejs_22
+      pnpm_10
+      pnpmConfigHook
+    ];
+
+    pnpmDeps = cliPnpmDeps;
+    pnpmRoot = "cli";
+
+    env.npm_config_manage_package_manager_versions = "false";
+
+    # FOD: allow network for nbb's git/maven fetches.
+    impureEnvVars = lib.fetchers.proxyImpureEnvVars;
+    outputHashMode = "recursive";
+    outputHashAlgo = "sha256";
+    outputHash = cliVendorHash;
+
+    buildPhase = ''
+      runHook preBuild
+      pushd cli
+      pnpm exec nbb-logseq -e :load-deps
+      popd
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      shopt -s nullglob
+      cache_dirs=(cli/.nbb/.cache/*/)
+      shopt -u nullglob
+      if [ ''${#cache_dirs[@]} -ne 1 ]; then
+        echo "ERROR: expected exactly one nbb cache dir, got ''${#cache_dirs[@]}" >&2
+        exit 1
+      fi
+      nbb_deps="''${cache_dirs[0]}nbb-deps"
+
+      mkdir -p $out
+      for dir in logseq malli borkdude medley; do
+        if [ ! -d "$nbb_deps/$dir" ]; then
+          echo "ERROR: missing $nbb_deps/$dir — upstream may have changed nbb-deps layout" >&2
+          exit 1
+        fi
+        cp -r "$nbb_deps/$dir" "$out/$dir"
+      done
+
+      runHook postInstall
+    '';
+
+    dontFixup = true;
   };
 
   # Build the CLI from an offline pnpm store.
@@ -95,6 +169,14 @@ let
       # Install the full deps tree (cli + sibling local deps)
       mkdir -p $out
       cp -r . $out/
+
+      # Wire up vendor sources next to cli/src so nbb-logseq can resolve
+      # logseq.common.graph-dir etc. at runtime. The bb task also drops
+      # nbb.edn so the runtime doesn't try to re-resolve deps from network.
+      mkdir -p $out/cli/vendor/src
+      cp -r ${cliVendor}/. $out/cli/vendor/src/
+      chmod -R u+w $out/cli/vendor
+      rm -f $out/cli/nbb.edn
 
       # Patch nbb_deps.js to use NBB_CACHE_DIR env var if set. The file is
       # minified, so upstream regularly renames local symbols while keeping the

--- a/lib/loadManifest.nix
+++ b/lib/loadManifest.nix
@@ -12,6 +12,7 @@ let
     "logseqVersion"
     "cliSrcHash"
     "cliPnpmDepsHash"
+    "cliVendorHash"
     "cliVersion"
   ];
   missing = lib.filter (key: !hasAttr key parsed) requiredKeys;
@@ -26,5 +27,6 @@ throwIf (missing != [ ]) "Manifest missing required keys: ${concatStringsSep ", 
     "assetSha256"
     "cliSrcHash"
     "cliPnpmDepsHash"
+    "cliVendorHash"
   ]
 )

--- a/scripts/update-nightly.sh
+++ b/scripts/update-nightly.sh
@@ -42,8 +42,8 @@ CLI_VERSION=$(curl -fsSL \
 echo "  cliVersion=$CLI_VERSION"
 echo "::endgroup::"
 
-# ── Phase 4: Write manifest with placeholder pnpm hash ──────────────
-echo "::group::Phase 4: Write manifest (placeholder pnpm hash)"
+# ── Phase 4: Write manifest with placeholder hashes ─────────────────
+echo "::group::Phase 4: Write manifest (placeholder pnpm/vendor hashes)"
 PLACEHOLDER="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 jq -n \
   --arg tag "$NIGHTLY_TAG" \
@@ -54,6 +54,7 @@ jq -n \
   --arg logseqVersion "$LOGSEQ_VERSION" \
   --arg cliSrcHash "$CLI_SRC_HASH" \
   --arg cliPnpmDepsHash "$PLACEHOLDER" \
+  --arg cliVendorHash "$PLACEHOLDER" \
   --arg cliVersion "$CLI_VERSION" \
   '{
     tag: $tag,
@@ -64,40 +65,51 @@ jq -n \
     logseqVersion: $logseqVersion,
     cliSrcHash: $cliSrcHash,
     cliPnpmDepsHash: $cliPnpmDepsHash,
+    cliVendorHash: $cliVendorHash,
     cliVersion: $cliVersion
   }' >"$MANIFEST"
-echo "  Wrote $MANIFEST with placeholder cliPnpmDepsHash"
+echo "  Wrote $MANIFEST with placeholder cliPnpmDepsHash, cliVendorHash"
 echo "::endgroup::"
 
-# ── Phase 5: Double-build to extract pnpm deps hash ─────────────────
-echo "::group::Phase 5: Double-build for pnpm deps hash"
-set +e
-BUILD_OUTPUT=$(nix build .#logseq-cli 2>&1)
-BUILD_EXIT=$?
-set -e
+# Helper: build with placeholder, parse `got: sha256-...` from the failure.
+extract_hash_from_build_failure() {
+  local field="$1"
+  local key_attr="$2"
+  set +e
+  local output
+  output=$(nix build ".#${key_attr}" 2>&1)
+  local exit_code=$?
+  set -e
+  if [ "$exit_code" -eq 0 ]; then
+    echo "ERROR: build of $key_attr succeeded with placeholder $field — should not happen" >&2
+    return 1
+  fi
+  local hash
+  hash=$(echo "$output" | sed -n 's/.*got: *\(sha256-[A-Za-z0-9+/=]\{44\}\).*/\1/p' | head -1)
+  if [ -z "$hash" ]; then
+    echo "ERROR: could not extract $field from build output" >&2
+    echo "$output" >&2
+    return 1
+  fi
+  echo "$hash"
+}
 
-if [ "$BUILD_EXIT" -eq 0 ]; then
-  echo "ERROR: nix build succeeded with placeholder hash — this should not happen" >&2
-  exit 1
-fi
-
-# ── Phase 6: Extract real hash from error output ─────────────────────
-PNPM_HASH=$(echo "$BUILD_OUTPUT" | sed -n 's/.*got: *\(sha256-[A-Za-z0-9+/=]\{44\}\).*/\1/p' | head -1)
-
-if [ -z "$PNPM_HASH" ]; then
-  echo "ERROR: Could not extract pnpm deps hash from build output" >&2
-  echo "Full build output:" >&2
-  echo "$BUILD_OUTPUT" >&2
-  exit 1
-fi
+# ── Phase 5: Resolve cliPnpmDepsHash ────────────────────────────────
+echo "::group::Phase 5: Resolve cliPnpmDepsHash"
+PNPM_HASH=$(extract_hash_from_build_failure cliPnpmDepsHash logseq-cli)
 echo "  cliPnpmDepsHash=$PNPM_HASH"
-echo "::endgroup::"
-
-# ── Phase 7: Rewrite manifest with real pnpm hash ────────────────────
-echo "::group::Phase 7: Finalize manifest"
 jq --arg hash "$PNPM_HASH" '.cliPnpmDepsHash = $hash' "$MANIFEST" >"${MANIFEST}.tmp"
 mv "${MANIFEST}.tmp" "$MANIFEST"
-echo "  Updated $MANIFEST with real cliPnpmDepsHash"
+echo "::endgroup::"
+
+# ── Phase 6: Resolve cliVendorHash ──────────────────────────────────
+# cliVendor depends on cliPnpmDeps, so the pnpm hash above must already be
+# correct in the manifest before we trigger the vendor build.
+echo "::group::Phase 6: Resolve cliVendorHash"
+VENDOR_HASH=$(extract_hash_from_build_failure cliVendorHash logseq-cli)
+echo "  cliVendorHash=$VENDOR_HASH"
+jq --arg hash "$VENDOR_HASH" '.cliVendorHash = $hash' "$MANIFEST" >"${MANIFEST}.tmp"
+mv "${MANIFEST}.tmp" "$MANIFEST"
 echo "::endgroup::"
 
 # ── Summary ──────────────────────────────────────────────────────────
@@ -109,4 +121,5 @@ echo "  logseqVersion:    $LOGSEQ_VERSION"
 echo "  assetSha256:      $ASSET_HASH"
 echo "  cliSrcHash:       $CLI_SRC_HASH"
 echo "  cliPnpmDepsHash:  $PNPM_HASH"
+echo "  cliVendorHash:    $VENDOR_HASH"
 echo "  cliVersion:       $CLI_VERSION"

--- a/scripts/update-nightly.sh
+++ b/scripts/update-nightly.sh
@@ -71,17 +71,22 @@ jq -n \
 echo "  Wrote $MANIFEST with placeholder cliPnpmDepsHash, cliVendorHash"
 echo "::endgroup::"
 
-# Helper: build with placeholder, parse `got: sha256-...` from the failure.
+# Helper: build a single FOD with a placeholder hash, parse the real
+# `got: sha256-...` line from the failure. Targets one FOD attr at a
+# time so the parsed hash is unambiguous even if Nix were to schedule
+# unrelated builds in parallel (`logseq-cli` transitively pulls in
+# both cliPnpmDeps and cliVendor; building one passthru attr forces
+# Nix to evaluate only that subgraph).
 extract_hash_from_build_failure() {
   local field="$1"
-  local key_attr="$2"
+  local target="$2"
   set +e
   local output
-  output=$(nix build ".#${key_attr}" 2>&1)
+  output=$(nix build ".#${target}" 2>&1)
   local exit_code=$?
   set -e
   if [ "$exit_code" -eq 0 ]; then
-    echo "ERROR: build of $key_attr succeeded with placeholder $field — should not happen" >&2
+    echo "ERROR: build of $target succeeded with placeholder $field — should not happen" >&2
     return 1
   fi
   local hash
@@ -96,7 +101,7 @@ extract_hash_from_build_failure() {
 
 # ── Phase 5: Resolve cliPnpmDepsHash ────────────────────────────────
 echo "::group::Phase 5: Resolve cliPnpmDepsHash"
-PNPM_HASH=$(extract_hash_from_build_failure cliPnpmDepsHash logseq-cli)
+PNPM_HASH=$(extract_hash_from_build_failure cliPnpmDepsHash logseq-cli.cliPnpmDeps)
 echo "  cliPnpmDepsHash=$PNPM_HASH"
 jq --arg hash "$PNPM_HASH" '.cliPnpmDepsHash = $hash' "$MANIFEST" >"${MANIFEST}.tmp"
 mv "${MANIFEST}.tmp" "$MANIFEST"
@@ -106,7 +111,7 @@ echo "::endgroup::"
 # cliVendor depends on cliPnpmDeps, so the pnpm hash above must already be
 # correct in the manifest before we trigger the vendor build.
 echo "::group::Phase 6: Resolve cliVendorHash"
-VENDOR_HASH=$(extract_hash_from_build_failure cliVendorHash logseq-cli)
+VENDOR_HASH=$(extract_hash_from_build_failure cliVendorHash logseq-cli.cliVendor)
 echo "  cliVendorHash=$VENDOR_HASH"
 jq --arg hash "$VENDOR_HASH" '.cliVendorHash = $hash' "$MANIFEST" >"${MANIFEST}.tmp"
 mv "${MANIFEST}.tmp" "$MANIFEST"


### PR DESCRIPTION
## Summary

The CLI's runtime classpath is `cli/src` + `cli/vendor/src` (set in `cli.mjs`), but the upstream tree we fetch via `fetchFromGitHub` doesn't ship a populated `vendor/`. Upstream produces it before publishing to npm via `bb build:vendor-nbb-deps`, which resolves nbb's deps and copies the relevant CLJS sources (logseq sibling deps, malli, borkdude, medley) out of `.nbb/.cache/<hash>/nbb-deps/` into `vendor/src/`. Without that step, `nbb-logseq` dies on the first `loadFile` with `Could not find namespace: logseq.common.graph-dir` (and many similar — every CLI subcommand was unusable).

## What this PR does

- Adds a fixed-output `cliVendor` derivation that replicates the bb task by running `pnpm exec nbb-logseq -e :load-deps` over the network. Output is just CLJS sources keyed by namespace, so the NAR hash is deterministic.
- `cliBuilt`'s installPhase copies `\${cliVendor}/.` into `cli/vendor/src/` and removes `cli/nbb.edn` to match what the bb task produces (so the runtime never tries to re-resolve deps from the network).
- Threads a new `cliVendorHash` field through the manifest schema, `loadManifest.nix` validation, and the flake's `callPackage`.
- Refactors the placeholder/parse hash discovery in `update-nightly.sh` into a shared helper used for both `cliPnpmDepsHash` and `cliVendorHash`.

## Stack

This PR is stacked on #20 (env-var fix for the pnpm auto-switch). Once #20 merges, this PR's base will retarget to `main` and only the vendor changes will remain in the diff.

## Test plan

- [x] `nix build .#logseq-cli` succeeds
- [x] `nix run .#logseq-cli list` enumerates real graphs (previously crashed at namespace load)
- [x] `mcp-server` subcommand gets past namespace loading
- [x] `nix flake check` clean