### PR TITLE
fix(nightly): stop desktop from installing cli launcher

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -114,10 +114,8 @@ jobs:
               if line.strip() != "(install-cli-launcher!)"
           ]
           removed = len(lines) - len(patched_lines)
-          if removed > 1:
-              raise SystemExit(f"expected at most one desktop CLI launcher install call, got {removed}")
-          if removed == 0:
-              print("desktop CLI launcher install call already absent")
+          if removed != 1:
+              raise SystemExit(f"expected exactly one desktop CLI launcher install call, got {removed}")
           patched = "".join(patched_lines)
           path.write_text(patched)
           PY

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -101,6 +101,31 @@ jobs:
           sed -i 's/defonce version ".*"/defonce version "${{ steps.version.outputs.value }}"/g' src/main/frontend/version.cljs
         working-directory: logseq-src
 
+      - name: Disable bundled desktop CLI launcher
+        run: |
+          python <<'PY'
+          from pathlib import Path
+
+          path = Path("src/electron/electron/core.cljs")
+          source = path.read_text()
+          old = """           (db/ensure-graphs-dir!)
+           (install-cli-launcher!)
+
+           ;; Windows/Linux: handle deeplink URL passed on first launch via argv
+          """
+          new = """           (db/ensure-graphs-dir!)
+
+           ;; Windows/Linux: handle deeplink URL passed on first launch via argv
+          """
+          patched = source.replace(old, new)
+          if patched == source:
+              raise SystemExit("expected to remove one desktop CLI launcher install call")
+          if patched.count("(install-cli-launcher!)") != source.count("(install-cli-launcher!)") - 1:
+              raise SystemExit("unexpected desktop CLI launcher install patch count")
+          path.write_text(patched)
+          PY
+        working-directory: logseq-src
+
       - name: Record source revision
         id: revision
         run: echo "rev=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -108,20 +108,17 @@ jobs:
 
           path = Path("src/electron/electron/core.cljs")
           source = path.read_text()
-          old = """           (db/ensure-graphs-dir!)
-           (install-cli-launcher!)
-
-           ;; Windows/Linux: handle deeplink URL passed on first launch via argv
-          """
-          new = """           (db/ensure-graphs-dir!)
-
-           ;; Windows/Linux: handle deeplink URL passed on first launch via argv
-          """
-          patched = source.replace(old, new)
-          if patched == source:
-              raise SystemExit("expected to remove one desktop CLI launcher install call")
-          if patched.count("(install-cli-launcher!)") != source.count("(install-cli-launcher!)") - 1:
-              raise SystemExit("unexpected desktop CLI launcher install patch count")
+          lines = source.splitlines(keepends=True)
+          patched_lines = [
+              line for line in lines
+              if line.strip() != "(install-cli-launcher!)"
+          ]
+          removed = len(lines) - len(patched_lines)
+          if removed > 1:
+              raise SystemExit(f"expected at most one desktop CLI launcher install call, got {removed}")
+          if removed == 0:
+              print("desktop CLI launcher install call already absent")
+          patched = "".join(patched_lines)
           path.write_text(patched)
           PY
         working-directory: logseq-src


### PR DESCRIPTION
## Summary
- patch upstream Logseq desktop source during the nightly build to remove the bundled CLI launcher install call
- keep the explicit Nix `logseq-cli` package as the CLI entrypoint while preserving `logseq` for the desktop app

## If `logseq` still runs the CLI after updating
Existing affected systems may already have a stale managed launcher at `~/.local/bin/logseq` from an earlier broken desktop launch. If the updated package still resolves `logseq` to the CLI, remove only the managed launcher:

```bash
grep -q 'logseq-cli-managed' ~/.local/bin/logseq && rm ~/.local/bin/logseq
hash -r 2>/dev/null || true
command -v -a logseq
command -v -a logseq-cli
```

## Validation
- `actionlint .github/workflows/nightly.yml`
- `git diff --check`
- verified the source patch removes one `(install-cli-launcher!)` call from the pinned upstream source