### PR TITLE
feat: build desktop and CLI for aarch64-linux

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -6,9 +6,16 @@
 -P ubuntu-latest=ghcr.io/catthehacker/ubuntu:act-latest
 -P ubuntu-24.04=ghcr.io/catthehacker/ubuntu:act-24.04
 -P ubuntu-22.04=ghcr.io/catthehacker/ubuntu:act-22.04
+# aarch64 runner: the catthehacker image is multi-arch. Run the arm64 job with an
+# explicit `--container-architecture linux/arm64` override. This requires the
+# qemu-aarch64 binfmt handler on the host:
+#   docker run --privileged --rm tonistiigi/binfmt --install arm64
+#   act -W .github/workflows/validate.yml -j validate-aarch64 --container-architecture linux/arm64
+-P ubuntu-24.04-arm=ghcr.io/catthehacker/ubuntu:act-latest
 
-# This flake targets x86_64-linux, and some Nix installer paths need elevated
-# container privileges under Docker.
+# This flake targets x86_64-linux by default, and some Nix installer paths need
+# elevated container privileges under Docker. The arm64 job overrides the
+# architecture on the command line (see above).
 --container-architecture=linux/amd64
 --container-options --privileged
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -309,6 +309,15 @@ jobs:
       - name: Update nightly manifest and CLI hashes
         run: bash scripts/update-nightly.sh
 
+      # Realize the architecture-independent CLI FODs with their freshly
+      # resolved hashes so Cachix uploads them; the aarch64 build substitutes
+      # these instead of running nbb's resolver, which fails on arm64.
+      - name: Seed CLI fixed-output derivations to Cachix
+        run: |
+          nix build --accept-flake-config --print-build-logs \
+            .#logseq-cli.cliVendor \
+            .#logseq-cli.cliPnpmDeps
+
       - name: Configure git
         run: |
           git config user.name "logseq-nightly-bot"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,12 +23,15 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.version.outputs.value }}
-      revision: ${{ steps.revision.outputs.rev }}
-      datestring: ${{ steps.metadata.outputs.date }}
-      hash: ${{ steps.package.outputs.hash }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v6
 
@@ -58,9 +61,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ steps.pnpm-store-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pnpm-
+            ${{ runner.os }}-${{ runner.arch }}-pnpm-
 
       - name: Cache Electron downloads
         uses: actions/cache@v5
@@ -68,9 +71,9 @@ jobs:
           path: |
             ~/.cache/electron
             ~/.cache/electron-builder
-          key: ${{ runner.os }}-electron-${{ hashFiles('logseq-src/resources/package.json', 'logseq-src/resources/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-electron-${{ hashFiles('logseq-src/resources/package.json', 'logseq-src/resources/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-electron-
+            ${{ runner.os }}-${{ runner.arch }}-electron-
 
       - name: Setup Java
         uses: actions/setup-java@v5
@@ -84,7 +87,7 @@ jobs:
           path: |
             ~/.m2/repository
             ~/.gitlibs
-          key: ${{ runner.os }}-clojure-${{ hashFiles('logseq-src/**/deps.edn') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-clojure-${{ hashFiles('logseq-src/**/deps.edn') }}
 
       - name: Setup Clojure CLI
         uses: DeLaGuardo/setup-clojure@13
@@ -186,7 +189,6 @@ jobs:
             accept-flake-config = true
 
       - name: Create tarball artifact
-        id: package
         working-directory: logseq-src/static
         run: |
           set -euo pipefail
@@ -197,13 +199,27 @@ jobs:
             find dist -maxdepth 2 -mindepth 1 -print >&2 || true
             exit 1
           fi
-          tarball="out/logseq-linux-x64-${{ steps.version.outputs.value }}.tar.gz"
+          arch="${{ matrix.arch }}"
+          version="${{ steps.version.outputs.value }}"
+          tarball="out/logseq-linux-${arch}-${version}.tar.gz"
           tar -C "$src_dir" -czf "$tarball" .
-          printf '%s\n' "${{ steps.version.outputs.value }}" > out/VERSION
+          printf '%s\n' "$version" >out/VERSION
           hash=$(nix hash path --type sha256 --sri "$src_dir")
-          echo "hash=$hash" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "$hash" >"out/hash-${arch}.txt"
+
+      - name: Write build metadata
+        if: matrix.arch == 'x64'
+        working-directory: logseq-src/static
+        run: |
+          set -euo pipefail
+          {
+            echo "version=${{ steps.version.outputs.value }}"
+            echo "revision=${{ steps.revision.outputs.rev }}"
+            echo "datestring=${{ steps.metadata.outputs.date }}"
+          } >out/meta.txt
 
       - name: Render release notes
+        if: matrix.arch == 'x64'
         working-directory: logseq-src
         env:
           LOGSEQ_REV: ${{ steps.revision.outputs.rev }}
@@ -214,11 +230,9 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v6
         with:
-          name: linux-build
-          path: |
-            logseq-src/static/out/logseq-linux-x64-${{ steps.version.outputs.value }}.tar.gz
-            logseq-src/static/out/VERSION
-            logseq-src/static/out/release-notes.md
+          name: linux-build-${{ matrix.arch }}
+          path: logseq-src/static/out/*
+          if-no-files-found: error
 
   publish-release:
     runs-on: ubuntu-latest
@@ -229,10 +243,44 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Download packaged build
+      - name: Download packaged builds
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh run download "${{ github.run_id }}" --repo "${{ github.repository }}" --name linux-build --dir builds
+        run: gh run download "${{ github.run_id }}" --repo "${{ github.repository }}" --dir builds
+
+      - name: Resolve build metadata
+        env:
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          meta="$(find builds -name meta.txt | head -1)"
+          x64_tar="$(find builds -name 'logseq-linux-x64-*.tar.gz' | head -1)"
+          arm64_tar="$(find builds -name 'logseq-linux-arm64-*.tar.gz' | head -1)"
+          notes="$(find builds -name release-notes.md | head -1)"
+          x64_hash_file="$(find builds -name 'hash-x64.txt' | head -1)"
+          arm64_hash_file="$(find builds -name 'hash-arm64.txt' | head -1)"
+          for f in "$meta" "$x64_tar" "$arm64_tar" "$notes" "$x64_hash_file" "$arm64_hash_file"; do
+            test -n "$f" || { echo "Required artifact file missing" >&2; exit 1; }
+          done
+          # meta.txt holds trusted build-step outputs (version/revision/datestring).
+          version="$(grep -E '^version=' "$meta" | cut -d= -f2-)"
+          revision="$(grep -E '^revision=' "$meta" | cut -d= -f2-)"
+          datestring="$(grep -E '^datestring=' "$meta" | cut -d= -f2-)"
+          tag="nightly-${datestring}"
+          {
+            echo "LOGSEQ_VERSION=${version}"
+            echo "LOGSEQ_REV=${revision}"
+            echo "NIGHTLY_TAG=${tag}"
+            echo "RELEASE_TAG=${tag}"
+            echo "BUILD_REVISION=${revision}"
+            echo "X64_TARBALL=${x64_tar}"
+            echo "ARM64_TARBALL=${arm64_tar}"
+            echo "RELEASE_NOTES=${notes}"
+            echo "ASSET_URL_X86_64=https://github.com/${REPO}/releases/download/${tag}/$(basename "$x64_tar")"
+            echo "ASSET_SHA256_X86_64=$(cat "$x64_hash_file")"
+            echo "ASSET_URL_AARCH64=https://github.com/${REPO}/releases/download/${tag}/$(basename "$arm64_tar")"
+            echo "ASSET_SHA256_AARCH64=$(cat "$arm64_hash_file")"
+          } >>"$GITHUB_ENV"
 
       - name: Install Nix
         uses: cachix/install-nix-action@v31
@@ -250,23 +298,15 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          tag="nightly-${{ needs.build.outputs.datestring }}"
-          rev="${{ needs.build.outputs.revision }}"
-          rev_short="${rev:0:7}"
-          gh release delete "$tag" -y || true
-          gh release create "$tag" builds/logseq-linux-x64-${{ needs.build.outputs.version }}.tar.gz \
+          set -euo pipefail
+          rev_short="${BUILD_REVISION:0:7}"
+          gh release delete "$RELEASE_TAG" -y || true
+          gh release create "$RELEASE_TAG" "$X64_TARBALL" "$ARM64_TARBALL" \
             --title "logseq-nightly-${rev_short}" \
-            --notes-file builds/release-notes.md \
+            --notes-file "$RELEASE_NOTES" \
             --target main
 
       - name: Update nightly manifest and CLI hashes
-        env:
-          LOGSEQ_REV: ${{ needs.build.outputs.revision }}
-          LOGSEQ_VERSION: ${{ needs.build.outputs.version }}
-          ASSET_URL: >-
-            https://github.com/${{ github.repository }}/releases/download/nightly-${{ needs.build.outputs.datestring }}/logseq-linux-x64-${{ needs.build.outputs.version }}.tar.gz
-          ASSET_HASH: ${{ needs.build.outputs.hash }}
-          NIGHTLY_TAG: nightly-${{ needs.build.outputs.datestring }}
         run: bash scripts/update-nightly.sh
 
       - name: Configure git

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,7 +22,21 @@ env:
   LOGSEQ_BRANCH: ${{ github.event.inputs.logseq_branch || 'master' }}
 
 jobs:
+  resolve-revision:
+    runs-on: ubuntu-latest
+    outputs:
+      rev: ${{ steps.resolve.outputs.rev }}
+    steps:
+      - name: Resolve upstream revision
+        id: resolve
+        run: |
+          set -euo pipefail
+          rev="$(git ls-remote https://github.com/logseq/logseq.git "refs/heads/${LOGSEQ_BRANCH}" | head -1 | cut -f1)"
+          test -n "$rev" || { echo "Could not resolve refs/heads/${LOGSEQ_BRANCH}" >&2; exit 1; }
+          echo "rev=${rev}" >>"$GITHUB_OUTPUT"
+
   build:
+    needs: resolve-revision
     strategy:
       fail-fast: false
       matrix:
@@ -36,7 +50,15 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Clone Logseq source
-        run: git clone --depth 1 --branch "${LOGSEQ_BRANCH}" https://github.com/logseq/logseq.git logseq-src
+        env:
+          LOGSEQ_REV: ${{ needs.resolve-revision.outputs.rev }}
+        run: |
+          set -euo pipefail
+          git init -q logseq-src
+          cd logseq-src
+          git remote add origin https://github.com/logseq/logseq.git
+          git fetch -q --depth 1 origin "${LOGSEQ_REV}"
+          git checkout -q FETCH_HEAD
 
       - name: Set nightly metadata
         id: metadata
@@ -193,9 +215,9 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p out
-          src_dir="dist/linux-unpacked"
-          if [ ! -d "$src_dir" ]; then
-            echo "Could not locate packaged Logseq bundle at $src_dir" >&2
+          src_dir="$(find dist -maxdepth 1 -type d -name 'linux*-unpacked' | head -1)"
+          if [ -z "$src_dir" ] || [ ! -d "$src_dir" ]; then
+            echo "Could not locate packaged Logseq bundle under dist/linux*-unpacked" >&2
             find dist -maxdepth 2 -mindepth 1 -print >&2 || true
             exit 1
           fi

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -37,6 +37,47 @@ jobs:
       - name: Run nix flake check
         run: nix flake check
 
+  validate-aarch64:
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v22
+        with:
+          determinate: false
+          extra-conf: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+
+      - name: Build and smoke-test logseq-cli (aarch64)
+        run: |
+          nix build --accept-flake-config --print-build-logs .#packages.aarch64-linux.logseq-cli
+          nix build --accept-flake-config --print-build-logs .#checks.aarch64-linux.logseq-cli-help
+
+      - name: Detect aarch64 desktop asset readiness
+        id: asset
+        run: |
+          set -euo pipefail
+          sha="$(jq -r '.assets["aarch64-linux"].sha256' data/logseq-nightly.json)"
+          placeholder="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+          if [ "$sha" = "$placeholder" ]; then
+            echo "ready=false" >>"$GITHUB_OUTPUT"
+            echo "::warning::aarch64 desktop asset is still a placeholder; skipping desktop build until the nightly publishes logseq-linux-arm64-*.tar.gz."
+          else
+            echo "ready=true" >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and smoke-test logseq desktop (aarch64)
+        if: steps.asset.outputs.ready == 'true'
+        run: |
+          nix build --accept-flake-config --print-build-logs .#packages.aarch64-linux.logseq
+          nix build --accept-flake-config --print-build-logs .#checks.aarch64-linux.logseq
+
   audit-flake-inputs:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -31,14 +31,31 @@ jobs:
             experimental-features = nix-command flakes
             accept-flake-config = true
 
+      - name: Setup Cachix
+        uses: cachix/cachix-action@v17
+        with:
+          name: nix-logseq-git-flake
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
       - name: Check formatting
         run: nix fmt -- --ci
 
       - name: Run nix flake check
         run: nix flake check
 
+      # nix flake check caches only check markers, not these intermediate FODs.
+      # Build them explicitly so Cachix uploads them: the aarch64 runner cannot
+      # run nbb's dep resolver, so it must substitute these content-addressed,
+      # architecture-independent paths instead of rebuilding them.
+      - name: Seed CLI fixed-output derivations for aarch64 substitution
+        run: |
+          nix build --accept-flake-config --print-build-logs \
+            .#logseq-cli.cliVendor \
+            .#logseq-cli.cliPnpmDeps
+
   validate-aarch64:
     runs-on: ubuntu-24.04-arm
+    needs: validate
     timeout-minutes: 45
     steps:
       - name: Checkout
@@ -53,6 +70,12 @@ jobs:
           extra-conf: |
             experimental-features = nix-command flakes
             accept-flake-config = true
+
+      - name: Setup Cachix
+        uses: cachix/cachix-action@v17
+        with:
+          name: nix-logseq-git-flake
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Build and smoke-test logseq-cli (aarch64)
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This file provides guidance to coding agents when working with this repository.
 
 ## Scope
 
-- This repo packages Logseq nightly builds as a Nix flake for Linux `x86_64-linux`.
+- This repo packages Logseq nightly builds as a Nix flake for Linux `x86_64-linux` and `aarch64-linux`.
 - Main outputs are `logseq` (desktop), `logseq-cli` (CLI), and `default` (both).
 - Most implementation work happens in `modules/`, `lib/loadManifest.nix`, `lib/runtime-libs.nix`, `scripts/update-nightly.sh`, `scripts/render-nightly-release-notes.sh`, and `.github/workflows/nightly.yml`.
 
@@ -32,13 +32,13 @@ This file provides guidance to coding agents when working with this repository.
 
 ### Nightly pipeline
 
-The flake does **not** build Logseq Desktop from source. It consumes a pre-packaged binary tarball from a GitHub Release, wraps it in an FHS env, and layers a desktop entry + icon. Only the CLI is built from source inside Nix.
+The flake does **not** build Logseq Desktop from source inside Nix. It consumes per-architecture pre-packaged binary tarballs (`x86_64` and `aarch64`) from a GitHub Release, wraps the one matching the build system in an FHS env, and layers a desktop entry + icon. The CLI is built from source inside Nix on both architectures.
 
 End-to-end data flow:
 
-1. `.github/workflows/nightly.yml` → `build` job runs on a GitHub-hosted Ubuntu runner **without** Nix. It clones upstream `logseq/logseq`, installs upstream pnpm dependencies, runs `pnpm gulp:build && pnpm cljs:release-electron && pnpm db-worker-node:bundle && pnpm webpack-app-build && pnpm desktop:prepare-runtime-js` to populate `static/` and stage runtime JS under `static/js/`, then runs `pnpm electron:make` (electron-builder) in `static/` to produce `static/dist/linux-unpacked/`. That directory is tarred as `logseq-linux-x64-<version>.tar.gz` and uploaded as an artifact.
-2. `.github/workflows/nightly.yml` → `publish-release` job installs Nix + Cachix, publishes the tarball as a GitHub Release tagged `nightly-<YYYYMMDD>`, then runs `bash scripts/update-nightly.sh`.
-3. `scripts/update-nightly.sh` rewrites `data/logseq-nightly.json` with the new release URL, SRI hash, upstream rev, and CLI version. It resolves `cliPnpmDepsHash` and `cliVendorHash` with deliberate placeholder fixed-output builds, parsing the resulting `got: sha256-...` error from stderr and rewriting the manifest after each hash.
+1. `.github/workflows/nightly.yml` → `build` job runs as a `strategy.matrix` over `{x64: ubuntu-latest, arm64: ubuntu-24.04-arm}`, **without** Nix. Each leg clones upstream `logseq/logseq`, installs upstream pnpm dependencies, runs `pnpm gulp:build && pnpm cljs:release-electron && pnpm db-worker-node:bundle && pnpm webpack-app-build && pnpm desktop:prepare-runtime-js` to populate `static/` and stage runtime JS under `static/js/`, then runs `pnpm electron:make` (electron-builder) in `static/` to produce `static/dist/linux-unpacked/` for that runner's architecture. The directory is tarred as `logseq-linux-<arch>-<version>.tar.gz` and uploaded as a per-arch artifact (`linux-build-<arch>`). Each leg also writes its SRI hash to `hash-<arch>.txt`; the x64 leg additionally writes shared `meta.txt` (version/revision/datestring) and the rendered release notes, because matrix job `outputs` are unreliable.
+2. `.github/workflows/nightly.yml` → `publish-release` job downloads both artifacts, resolves shared metadata + per-arch hashes from those files, installs Nix + Cachix, publishes **both** tarballs as a GitHub Release tagged `nightly-<YYYYMMDD>`, then runs `bash scripts/update-nightly.sh`.
+3. `scripts/update-nightly.sh` rewrites `data/logseq-nightly.json` with the per-architecture release URLs + SRI hashes (under `assets.<system>`), upstream rev, and CLI version. It resolves `cliPnpmDepsHash` and `cliVendorHash` with deliberate placeholder fixed-output builds, parsing the resulting `got: sha256-...` error from stderr and rewriting the manifest after each hash.
 4. `nix flake check` validates the updated manifest through `lib/loadManifest.nix`, rebuilds both packages, then the `logseq-nightly-bot` auto-commits the manifest bump to `main`.
 
 The manifest is the single source of truth for downstream consumers. Adding a field requires updating **both** `scripts/update-nightly.sh` (producer) **and** `lib/loadManifest.nix` (validator) in the same change.
@@ -46,9 +46,9 @@ The manifest is the single source of truth for downstream consumers. Adding a fi
 ### Manifest fan-out inside flake modules
 
 - `modules/logseq-scope.nix` loads `data/logseq-nightly.json` through `lib/loadManifest.nix` and exposes the shared package set as a per-system module argument.
-- `modules/_packages/desktop/payload.nix` fetches the desktop bundle from `manifest.assetUrl` with `manifest.assetSha256`.
+- `modules/_packages/desktop/payload.nix` selects the per-system desktop bundle from `manifest.assets.<system>` (`url` + `sha256`), keyed by `pkgs.stdenv.hostPlatform.system`, and throws on an unsupported system.
 - `modules/_packages/desktop/upstream-source.nix` fetches `logseq/logseq` at `manifest.logseqRev` with `manifest.cliSrcHash`; this source is shared by the desktop icon and CLI build.
-- `modules/_packages/logseq-cli/` also reads `cliPnpmDepsHash`, `cliVendorHash`, and `cliVersion`. The pnpm hash feeds the offline pnpm store; the vendor hash pins the fixed-output nbb dependency source tree copied into `cli/vendor/src`.
+- `modules/_packages/logseq-cli/` also reads `cliPnpmDepsHash`, `cliVendorHash`, and `cliVersion`. The pnpm hash feeds the offline pnpm store; the vendor hash pins the fixed-output nbb dependency source tree copied into `cli/vendor/src`. The CLI builds from source on both `x86_64-linux` and `aarch64-linux`; these two hashes are currently shared across architectures (the vendor tree is pure ClojureScript source, and the pnpm fetch is expected to be platform-independent). If an aarch64 build ever reports a pnpm hash mismatch, split `cliPnpmDepsHash` per system in the manifest, validator, and producer together.
 
 ### Upstream layout assumptions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ The flake does **not** build Logseq Desktop from source inside Nix. It consumes 
 
 End-to-end data flow:
 
-1. `.github/workflows/nightly.yml` → `build` job runs as a `strategy.matrix` over `{x64: ubuntu-latest, arm64: ubuntu-24.04-arm}`, **without** Nix. Each leg clones upstream `logseq/logseq`, installs upstream pnpm dependencies, runs `pnpm gulp:build && pnpm cljs:release-electron && pnpm db-worker-node:bundle && pnpm webpack-app-build && pnpm desktop:prepare-runtime-js` to populate `static/` and stage runtime JS under `static/js/`, then runs `pnpm electron:make` (electron-builder) in `static/` to produce `static/dist/linux-unpacked/` for that runner's architecture. The directory is tarred as `logseq-linux-<arch>-<version>.tar.gz` and uploaded as a per-arch artifact (`linux-build-<arch>`). Each leg also writes its SRI hash to `hash-<arch>.txt`; the x64 leg additionally writes shared `meta.txt` (version/revision/datestring) and the rendered release notes, because matrix job `outputs` are unreliable.
+1. `.github/workflows/nightly.yml` → `build` job runs as a `strategy.matrix` over `{x64: ubuntu-latest, arm64: ubuntu-24.04-arm}`, **without** Nix. Each leg clones upstream `logseq/logseq`, installs upstream pnpm dependencies, runs `pnpm gulp:build && pnpm cljs:release-electron && pnpm db-worker-node:bundle && pnpm webpack-app-build && pnpm desktop:prepare-runtime-js` to populate `static/` and stage runtime JS under `static/js/`, then runs `pnpm electron:make` (electron-builder) in `static/` to produce the unpacked bundle for that runner's architecture under `static/dist/` (`linux-unpacked` on x64, `linux-arm64-unpacked` on arm64). The directory is tarred as `logseq-linux-<arch>-<version>.tar.gz` and uploaded as a per-arch artifact (`linux-build-<arch>`). Each leg also writes its SRI hash to `hash-<arch>.txt`; the x64 leg additionally writes shared `meta.txt` (version/revision/datestring) and the rendered release notes, because matrix job `outputs` are unreliable.
 2. `.github/workflows/nightly.yml` → `publish-release` job downloads both artifacts, resolves shared metadata + per-arch hashes from those files, installs Nix + Cachix, publishes **both** tarballs as a GitHub Release tagged `nightly-<YYYYMMDD>`, then runs `bash scripts/update-nightly.sh`.
 3. `scripts/update-nightly.sh` rewrites `data/logseq-nightly.json` with the per-architecture release URLs + SRI hashes (under `assets.<system>`), upstream rev, and CLI version. It resolves `cliPnpmDepsHash` and `cliVendorHash` with deliberate placeholder fixed-output builds, parsing the resulting `got: sha256-...` error from stderr and rewriting the manifest after each hash.
 4. `nix flake check` validates the updated manifest through `lib/loadManifest.nix`, rebuilds both packages, then the `logseq-nightly-bot` auto-commits the manifest bump to `main`.
@@ -147,7 +147,7 @@ nix run nixpkgs#flake-checker -- \
 bash scripts/update-nightly.sh
 ```
 
-Required env vars for `scripts/update-nightly.sh`: `LOGSEQ_REV`, `LOGSEQ_VERSION`, `ASSET_URL`, `ASSET_HASH`, `NIGHTLY_TAG`.
+Required env vars for `scripts/update-nightly.sh`: `LOGSEQ_REV`, `LOGSEQ_VERSION`, `ASSET_URL_X86_64`, `ASSET_SHA256_X86_64`, `ASSET_URL_AARCH64`, `ASSET_SHA256_AARCH64`, `NIGHTLY_TAG`.
 
 ## What To Run After Common Changes
 

--- a/data/logseq-nightly.json
+++ b/data/logseq-nightly.json
@@ -1,8 +1,16 @@
 {
   "tag": "nightly-20260525",
   "publishedAt": "2026-05-25T04:49:29Z",
-  "assetUrl": "https://github.com/Bad3r/nix-logseq-git-flake/releases/download/nightly-20260525/logseq-linux-x64-2.0.1-alpha+nightly.20260525.tar.gz",
-  "assetSha256": "sha256-8sAxa+kq3Xmh7sXYOBWfUhp1AYbdEK+mjZmSaItiyVM=",
+  "assets": {
+    "x86_64-linux": {
+      "url": "https://github.com/Bad3r/nix-logseq-git-flake/releases/download/nightly-20260525/logseq-linux-x64-2.0.1-alpha+nightly.20260525.tar.gz",
+      "sha256": "sha256-8sAxa+kq3Xmh7sXYOBWfUhp1AYbdEK+mjZmSaItiyVM="
+    },
+    "aarch64-linux": {
+      "url": "https://github.com/Bad3r/nix-logseq-git-flake/releases/download/nightly-20260525/logseq-linux-arm64-2.0.1-alpha+nightly.20260525.tar.gz",
+      "sha256": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+    }
+  },
   "logseqRev": "2efa164717e87be3722064186d57b1387911ea22",
   "logseqVersion": "2.0.1-alpha+nightly.20260525",
   "cliSrcHash": "sha256-HCDQddowWj+w/xJD3uDSq3S44HGBImAF6vCWRNh81zg=",

--- a/lib/loadManifest.nix
+++ b/lib/loadManifest.nix
@@ -1,13 +1,19 @@
 { lib, manifestPath }:
 let
-  inherit (builtins) fromJSON hasAttr readFile;
+  inherit (builtins)
+    attrNames
+    foldl'
+    fromJSON
+    hasAttr
+    isString
+    readFile
+    ;
   inherit (lib) concatStringsSep hasPrefix throwIf;
   parsed = fromJSON (readFile manifestPath);
   requiredKeys = [
     "tag"
     "publishedAt"
-    "assetUrl"
-    "assetSha256"
+    "assets"
     "logseqRev"
     "logseqVersion"
     "cliSrcHash"
@@ -16,17 +22,32 @@ let
     "cliVersion"
   ];
   missing = lib.filter (key: !hasAttr key parsed) requiredKeys;
+
   validateHash =
     acc: key:
     throwIf (
       !hasPrefix "sha256-" parsed.${key}
     ) "Manifest ${key} must begin with sha256- (Nix SRI)." acc;
+
+  # Each per-system desktop asset must carry a string url and an SRI sha256.
+  assetSystems = if hasAttr "assets" parsed then attrNames parsed.assets else [ ];
+  validateAsset =
+    acc: system:
+    let
+      entry = parsed.assets.${system};
+    in
+    throwIf (!(hasAttr "url" entry && isString entry.url))
+      "Manifest assets.${system}.url must be a string."
+      (
+        throwIf (
+          !(hasAttr "sha256" entry && hasPrefix "sha256-" entry.sha256)
+        ) "Manifest assets.${system}.sha256 must begin with sha256- (Nix SRI)." acc
+      );
 in
 throwIf (missing != [ ]) "Manifest missing required keys: ${concatStringsSep ", " missing}" (
-  builtins.foldl' validateHash parsed [
-    "assetSha256"
+  foldl' validateAsset (foldl' validateHash parsed [
     "cliSrcHash"
     "cliPnpmDepsHash"
     "cliVendorHash"
-  ]
+  ]) assetSystems
 )

--- a/modules/_packages/desktop/payload.nix
+++ b/modules/_packages/desktop/payload.nix
@@ -1,6 +1,12 @@
 { manifest, pkgs }:
+let
+  inherit (pkgs.stdenv.hostPlatform) system;
+  asset =
+    manifest.assets.${system}
+      or (throw "logseq desktop: no asset for system ${system} in manifest.assets");
+in
 pkgs.fetchzip {
-  url = manifest.assetUrl;
-  hash = manifest.assetSha256;
+  inherit (asset) url;
+  hash = asset.sha256;
   stripRoot = false;
 }

--- a/modules/systems.nix
+++ b/modules/systems.nix
@@ -1,3 +1,6 @@
 {
-  systems = [ "x86_64-linux" ];
+  systems = [
+    "x86_64-linux"
+    "aarch64-linux"
+  ];
 }

--- a/scripts/update-nightly.sh
+++ b/scripts/update-nightly.sh
@@ -2,11 +2,13 @@
 # update-nightly.sh — Compute all hashes and write data/logseq-nightly.json
 #
 # Required environment variables:
-#   LOGSEQ_REV      — upstream commit SHA
-#   LOGSEQ_VERSION  — version string (e.g. 2.0.0-alpha+nightly.20260127)
-#   ASSET_URL       — tarball download URL
-#   ASSET_HASH      — SRI hash of the desktop tarball
-#   NIGHTLY_TAG     — release tag (e.g. nightly-20260127)
+#   LOGSEQ_REV             — upstream commit SHA
+#   LOGSEQ_VERSION         — version string (e.g. 2.0.0-alpha+nightly.20260127)
+#   ASSET_URL_X86_64       — x86_64 desktop tarball download URL
+#   ASSET_SHA256_X86_64    — SRI hash of the x86_64 desktop tarball
+#   ASSET_URL_AARCH64      — aarch64 desktop tarball download URL
+#   ASSET_SHA256_AARCH64   — SRI hash of the aarch64 desktop tarball
+#   NIGHTLY_TAG            — release tag (e.g. nightly-20260127)
 
 set -euo pipefail
 
@@ -16,8 +18,10 @@ MANIFEST="data/logseq-nightly.json"
 echo "::group::Phase 1: Validate inputs"
 : "${LOGSEQ_REV:?must be set}"
 : "${LOGSEQ_VERSION:?must be set}"
-: "${ASSET_URL:?must be set}"
-: "${ASSET_HASH:?must be set}"
+: "${ASSET_URL_X86_64:?must be set}"
+: "${ASSET_SHA256_X86_64:?must be set}"
+: "${ASSET_URL_AARCH64:?must be set}"
+: "${ASSET_SHA256_AARCH64:?must be set}"
 : "${NIGHTLY_TAG:?must be set}"
 PUBLISHED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 echo "All inputs validated"
@@ -48,8 +52,10 @@ PLACEHOLDER="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 jq -n \
   --arg tag "$NIGHTLY_TAG" \
   --arg publishedAt "$PUBLISHED_AT" \
-  --arg assetUrl "$ASSET_URL" \
-  --arg assetSha256 "$ASSET_HASH" \
+  --arg urlX86_64 "$ASSET_URL_X86_64" \
+  --arg sha256X86_64 "$ASSET_SHA256_X86_64" \
+  --arg urlAarch64 "$ASSET_URL_AARCH64" \
+  --arg sha256Aarch64 "$ASSET_SHA256_AARCH64" \
   --arg logseqRev "$LOGSEQ_REV" \
   --arg logseqVersion "$LOGSEQ_VERSION" \
   --arg cliSrcHash "$CLI_SRC_HASH" \
@@ -59,8 +65,10 @@ jq -n \
   '{
     tag: $tag,
     publishedAt: $publishedAt,
-    assetUrl: $assetUrl,
-    assetSha256: $assetSha256,
+    assets: {
+      "x86_64-linux": { url: $urlX86_64, sha256: $sha256X86_64 },
+      "aarch64-linux": { url: $urlAarch64, sha256: $sha256Aarch64 }
+    },
     logseqRev: $logseqRev,
     logseqVersion: $logseqVersion,
     cliSrcHash: $cliSrcHash,
@@ -123,7 +131,8 @@ echo "=== Manifest updated ==="
 echo "  tag:              $NIGHTLY_TAG"
 echo "  logseqRev:        $LOGSEQ_REV"
 echo "  logseqVersion:    $LOGSEQ_VERSION"
-echo "  assetSha256:      $ASSET_HASH"
+echo "  assetSha256(x64): $ASSET_SHA256_X86_64"
+echo "  assetSha256(arm): $ASSET_SHA256_AARCH64"
 echo "  cliSrcHash:       $CLI_SRC_HASH"
 echo "  cliPnpmDepsHash:  $PNPM_HASH"
 echo "  cliVendorHash:    $VENDOR_HASH"


### PR DESCRIPTION
closes: #27 

## Summary

- Make the flake architecture-aware for `aarch64-linux`: add it to
  `modules/systems.nix`, switch the manifest to a per-system `assets` map
  (per-arch `url` + `sha256`), and update the validator
  (`lib/loadManifest.nix`) and producer (`scripts/update-nightly.sh`)
  together. `modules/_packages/desktop/payload.nix` selects the per-system
  bundle keyed by `pkgs.stdenv.hostPlatform.system`.
- Nightly `build` job is now a matrix over `{x64: ubuntu-latest, arm64:
  ubuntu-24.04-arm}` and publishes both desktop tarballs per release; the CLI
  builds from source on both architectures.
- Seed the architecture-independent CLI fixed-output derivations
  (`cliVendor`, `cliPnpmDeps`) to Cachix from x86_64. nbb's `-e :load-deps`
  resolver crashes on arm64, but these FODs are content-addressed (identical
  store path on every system), so the arm64 runner substitutes them and builds
  only the native parts (cljs + better-sqlite3). `validate-aarch64` runs after
  `validate` (`needs:`) so the cache is seeded before the arm64 job consumes it.

## Test plan

- [x] CLI build + run on native arm64 (`ubuntu-24.04-arm`): `validate-aarch64`
  substituted the seeded FODs and natively built `logseq-cli-built`,
  `logseq-cli-wrapper`, `logseq-cli`, and the `logseq-cli-help` smoke check
  (which runs the binary).
  https://github.com/Bad3r/nix-logseq-git-flake/actions/runs/26405230706
- [x] x86_64 `nix flake check` and `nix fmt -- --ci` pass.
- [ ] Desktop on arm64: gated behind the arm64 desktop asset, a placeholder
  until the nightly publishes `logseq-linux-arm64-*.tar.gz`. `validate-aarch64`
  skips the desktop build (with a `::warning::`) while the placeholder is
  present and builds it once the asset is real. After merge, a nightly run on
  `main` publishes the arm64 tarball and verifies the desktop on arm64.

Note: this PR edits `.github/workflows/*`, so the policy check requires the
`status(security-review-approved)` label before merge.