### PR TITLE
fix: patch upstream login crash (React #310) and CLI auth callback bind

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -71,6 +71,22 @@ jobs:
           git fetch -q --depth 1 origin "${LOGSEQ_REV}"
           git checkout -q FETCH_HEAD
 
+      # Temporary upstream fixes tracked under patches/; each patch header
+      # documents the bug and its removal condition. Strict apply fails the
+      # build when upstream drifts or lands the fix, which is the signal to
+      # update or drop the patch file.
+      - name: Apply upstream patches
+        working-directory: logseq-src
+        run: |
+          set -euo pipefail
+          applied=0
+          for patch in ../patches/logseq-*.patch; do
+            [ -e "$patch" ] || continue
+            git apply --verbose "$patch"
+            applied=$((applied + 1))
+          done
+          echo "Applied ${applied} upstream patch(es)"
+
       - name: Set nightly metadata
         id: metadata
         run: echo "date=$(date -u +%Y%m%d)" >> "$GITHUB_OUTPUT"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ This file provides guidance to coding agents when working with this repository.
 - `modules/_packages/logseq-cli/` builds the upstream CLI from the Logseq monorepo as a shadow-cljs `:node-script` release, with offline pnpm deps and an offline Clojure dependency tree (Maven jars plus tools.gitlibs git checkouts).
 - `scripts/update-nightly.sh` regenerates manifest fields, CLI source/dependency hashes, and the CLI Clojure-deps hash.
 - `scripts/render-nightly-release-notes.sh` renders release notes from the cloned upstream Logseq repo.
+- `patches/` carries temporary fixes for upstream Logseq source; each patch header documents the bug and its removal condition.
 - `.actrc` is tracked local `act` configuration; `.act/` is runtime state and stays ignored.
 - `.github/workflows/validate.yml` is the clearest snapshot of CI expectations.
 
@@ -37,7 +38,7 @@ The flake does **not** build Logseq Desktop from source inside Nix. It consumes 
 
 End-to-end data flow:
 
-1. `.github/workflows/nightly.yml` -> `build` job runs as a `strategy.matrix` over Linux x64 (`ubuntu-24.04`), Linux arm64 (`ubuntu-24.04-arm`), and Darwin arm64 (`macos-26`), **without** Nix during upstream compilation. Each leg clones upstream `logseq/logseq`, installs upstream pnpm dependencies, runs `pnpm gulp:build && pnpm cljs:release-electron && pnpm db-worker-node:bundle && pnpm webpack-app-build && pnpm desktop:prepare-runtime-js` to populate `static/` and stage runtime JS under `static/js/`. Linux runs `pnpm electron:make` and packages `dist/linux*-unpacked` as `logseq-linux-<arch>-<version>.tar.gz`. Darwin verifies `rebuild:all` and `electron:make-macos-arm64`, runs `pnpm rebuild:all && pnpm electron:make-macos-arm64`, copies the single `dist/mac-arm64/*.app` into a clean top-level `Logseq.app` payload, ad-hoc signs it, then packages `logseq-darwin-arm64-<version>.tar.gz`. Each leg writes an SRI hash file; the x64 leg additionally writes shared `meta.txt` (version/revision/datestring) and rendered release notes, because matrix job `outputs` are unreliable.
+1. `.github/workflows/nightly.yml` -> `build` job runs as a `strategy.matrix` over Linux x64 (`ubuntu-24.04`), Linux arm64 (`ubuntu-24.04-arm`), and Darwin arm64 (`macos-26`), **without** Nix during upstream compilation. Each leg clones upstream `logseq/logseq`, strict-applies `patches/logseq-*.patch`, installs upstream pnpm dependencies, runs `pnpm gulp:build && pnpm cljs:release-electron && pnpm db-worker-node:bundle && pnpm webpack-app-build && pnpm desktop:prepare-runtime-js` to populate `static/` and stage runtime JS under `static/js/`. Linux runs `pnpm electron:make` and packages `dist/linux*-unpacked` as `logseq-linux-<arch>-<version>.tar.gz`. Darwin verifies `rebuild:all` and `electron:make-macos-arm64`, runs `pnpm rebuild:all && pnpm electron:make-macos-arm64`, copies the single `dist/mac-arm64/*.app` into a clean top-level `Logseq.app` payload, ad-hoc signs it, then packages `logseq-darwin-arm64-<version>.tar.gz`. Each leg writes an SRI hash file; the x64 leg additionally writes shared `meta.txt` (version/revision/datestring) and rendered release notes, because matrix job `outputs` are unreliable.
 2. `.github/workflows/nightly.yml` -> `publish-release` job downloads build artifacts, resolves shared metadata + per-system hashes, requires Linux and Darwin tarballs plus their SRI hash files, installs Nix + Cachix, publishes all three tarballs, then runs `bash scripts/update-nightly.sh`. The Darwin matrix leg is release-blocking, so a Darwin build failure or missing Darwin artifact prevents publishing. `workflow_dispatch` can set `publish_release=false` to validate the build matrix without creating a release or committing a manifest bump.
 3. `scripts/update-nightly.sh` rewrites `data/logseq-nightly.json` with the per-system release URLs + SRI hashes (under `assets.<system>`), upstream rev, and CLI version. It requires `ASSET_URL_X86_64`, `ASSET_SHA256_X86_64`, `ASSET_URL_AARCH64`, `ASSET_SHA256_AARCH64`, `ASSET_URL_AARCH64_DARWIN`, and `ASSET_SHA256_AARCH64_DARWIN`. It resolves `cliPnpmDepsHash` and `cliCljDepsHash` with deliberate placeholder fixed-output builds, parsing the resulting `got: sha256-...` error from stderr and rewriting the manifest after each hash.
 4. `nix flake check` validates the updated manifest through `lib/loadManifest.nix`, rebuilds both packages, then the `logseq-nightly-bot` auto-commits the manifest bump to `main`.
@@ -63,6 +64,15 @@ The bundle's internal layout is dictated by upstream's packaging tool and change
 `logseqTree` in `modules/_packages/desktop/tree.nix` expects the flat electron-builder payload on Linux and a single top-level `Logseq.app` payload on Darwin. Linux copies the flat tree directly and the FHS `runScript` executes `share/logseq/logseq`. Darwin copies the app to `Logseq.app`; `package-darwin.nix` later installs it under `$out/Applications/Logseq.app` and re-signs the installed copy. If upstream reintroduces a nested Linux bundle root, renames the Linux executable, or changes the Darwin app name/layout, fix tree normalization and the launcher/package path together. The Linux icon is fetched from `logseqSrc` (upstream repo at pinned rev), not extracted from the tarball, because asar-packed resources aren't filesystem-accessible.
 
 When a nightly fails, first check whether upstream renamed a path, changed the packaging tool, or moved an expected file. The cleanest signal is usually a diff of upstream's `.github/workflows/build-desktop-release.yml` around the failing step.
+
+### Upstream patches
+
+`patches/` holds temporary unified diffs against the upstream Logseq tree for bugs that upstream has not fixed yet. Two consumers apply them:
+
+- `.github/workflows/build-desktop.yml` strict-applies every `patches/logseq-*.patch` with `git apply` right after cloning upstream, so the desktop tarballs (and the bundled `static/js/logseq-cli.js`) ship the fixes.
+- `modules/_packages/logseq-cli/build.nix` lists only the patches that touch files compiled into the CLI in its `patches` attribute. Patching happens in the build derivation, not the source FOD, so `cliSrcHash`, `cliPnpmDepsHash`, and `cliCljDepsHash` stay unchanged.
+
+Rules: every patch header must explain the bug and name its removal condition. Strict apply is the drift guard; when a nightly or CLI build fails at patch application, upstream either landed the fix (delete the patch and its `build.nix` reference) or moved the code (regenerate the patch against the new tree). Keep the two apply sites in sync in the same change. Verify a new or regenerated patch with `git apply --check` against a checkout of `manifest.logseqRev` before committing.
 
 ### Desktop packaging
 
@@ -98,6 +108,7 @@ nix build .#checks.x86_64-linux.logseq-runtime-assets
 nix build .#checks.x86_64-linux.logseq
 nix build .#checks.x86_64-linux.logseq-cli
 nix build .#checks.x86_64-linux.logseq-cli-help
+nix build .#checks.x86_64-linux.logseq-cli-login-callback
 nix build .#checks.x86_64-linux.pre-commit-check
 nix eval --accept-flake-config .#packages.aarch64-darwin.logseq.meta.mainProgram
 nix eval --accept-flake-config .#packages.aarch64-darwin.logseq-cli.meta.mainProgram
@@ -160,6 +171,7 @@ Required env vars for `scripts/update-nightly.sh`: `LOGSEQ_REV`, `LOGSEQ_VERSION
 
 - `flake.nix` or `modules/**`: run `nix fmt`, `nix flake show --all-systems --accept-flake-config`, the relevant Darwin metadata evals when Darwin outputs are touched, and at least one targeted build or check attr.
 - `modules/_packages/logseq-cli/**`: run `nix build .#logseq-cli` or `nix build .#checks.x86_64-linux.logseq-cli-help`; the smoke check runs `logseq-cli doctor` plus a db-worker spawn probe (`graph create` then `list page`), exercising the shadow-cljs runtime and the bundled `db-worker-node.js`. The worker requires `keytar`, whose native binding is built from source with node-gyp (`libsecret` on Linux); keychain operations additionally need a running secret service at runtime. Darwin CLI changes also need GitHub `validate-aarch64-darwin` because the local host is Linux.
+- `patches/**`: verify each changed patch with `git apply --check` against a checkout of `manifest.logseqRev`, then run `nix build .#logseq-cli` and `nix build .#checks.x86_64-linux.logseq-cli-login-callback` when the patch affects the CLI. Desktop-only patches get exercised by the next nightly (or a `test-build` run); there is no local desktop compile.
 - `lib/loadManifest.nix` or `data/logseq-nightly.json`: run `nix build .#checks.x86_64-linux.logseq-runtime-assets` for desktop ASAR layout changes, or `nix flake check` for broader manifest/load-path changes. For Darwin asset changes, use the `aarch64-darwin` runtime-assets check in CI once the Darwin hash is real.
 - `flake.lock`: if the bump changes `git` or `zlib`, the CLI Clojure-deps FOD output can change bytes (its git deps are exploded to loose objects, whose encoding depends on those tools), so `nix build .#logseq-cli` fails with a `cliCljDepsHash` mismatch until `scripts/update-nightly.sh` re-resolves the hash; the nightly workflow is the only flow that re-resolves it automatically. Validate lock bumps with `nix build .#checks.x86_64-linux.logseq-cli` (or the `logseq-cli-help` check) before merging.
 - `.github/workflows/*.yml` or `scripts/*.sh`: run the relevant formatter, then `nix develop -c pre-commit run --all-files` if practical. Use the long-running local `act` build only when the workflow or script change materially affects the nightly build path and smaller checks cannot cover it.

--- a/modules/_checks/cli-login-callback.nix
+++ b/modules/_checks/cli-login-callback.nix
@@ -1,0 +1,112 @@
+{ cli, pkgs }:
+# Regression check for the patches/logseq-cli-auth-bind-ipv4-loopback.patch
+# behavior: `logseq-cli login` must serve its OAuth callback on the IPv4
+# loopback literal. Upstream binds the resolver's first "localhost" address
+# (often ::1 only), which IPv4-only browsers cannot reach. The probe stays
+# hermetic: the browser opener is stubbed to capture the authorize URL, and a
+# deliberate state mismatch makes the CLI reject the callback before any
+# token-exchange network traffic.
+let
+  # login! spawns `xdg-open <url>` on Linux and `open <url>` on Darwin via
+  # PATH lookup; capture the URL instead of opening a browser. The temp file
+  # plus mv keeps readers from seeing a partially written URL.
+  openerStub = pkgs.writeShellScript "browser-opener-stub" ''
+    printf '%s\n' "$1" >"$TMPDIR/authorize-url.tmp"
+    mv "$TMPDIR/authorize-url.tmp" "$TMPDIR/authorize-url"
+  '';
+in
+pkgs.runCommand "logseq-cli-login-callback-check" { } ''
+  export HOME=$TMPDIR
+  export XDG_CACHE_HOME=$TMPDIR/cache
+
+  mkdir -p "$TMPDIR/bin"
+  ln -s ${openerStub} "$TMPDIR/bin/xdg-open"
+  ln -s ${openerStub} "$TMPDIR/bin/open"
+  export PATH="$TMPDIR/bin:$PATH"
+
+  ${cli}/bin/logseq-cli login >"$TMPDIR/login-output" 2>&1 &
+  login_pid=$!
+
+  # The authorize URL is written only after the callback server's listen
+  # callback resolved, so its presence means the server is accepting
+  # connections.
+  tries=0
+  while [ ! -s "$TMPDIR/authorize-url" ]; do
+    tries=$((tries + 1))
+    if [ "$tries" -gt 120 ]; then
+      echo "logseq-cli login did not produce an authorize URL within 120s" >&2
+      cat "$TMPDIR/login-output" >&2
+      kill "$login_pid" 2>/dev/null || true
+      exit 1
+    fi
+    if ! kill -0 "$login_pid" 2>/dev/null; then
+      echo "logseq-cli login exited before opening the browser:" >&2
+      cat "$TMPDIR/login-output" >&2
+      exit 1
+    fi
+    sleep 1
+  done
+
+  authorize_url="$(cat "$TMPDIR/authorize-url")"
+  state="$(printf '%s' "$authorize_url" | ${pkgs.gnused}/bin/sed -n 's/.*[?&]state=\([^&]*\).*/\1/p')"
+  if [ -z "$state" ]; then
+    echo "authorize URL is missing the OAuth state parameter:" >&2
+    printf '%s\n' "$authorize_url" >&2
+    kill "$login_pid" 2>/dev/null || true
+    exit 1
+  fi
+
+  # The probe under test: an IPv4-only client must reach the callback server.
+  # A connection failure here is the exact regression this check pins down
+  # (server bound to ::1 only).
+  http_status=0
+  if ! http_status="$(${pkgs.curl}/bin/curl --silent --show-error --max-time 10 \
+    --output "$TMPDIR/callback-body" --write-out '%{http_code}' \
+    "http://127.0.0.1:8765/auth/callback?code=probe&state=mismatch-$state")"; then
+    echo "callback probe could not connect to 127.0.0.1:8765; the login server is not bound on the IPv4 loopback" >&2
+    cat "$TMPDIR/login-output" >&2
+    kill "$login_pid" 2>/dev/null || true
+    exit 1
+  fi
+
+  if [ "$http_status" != "400" ]; then
+    echo "expected HTTP 400 for a state-mismatch callback, got $http_status" >&2
+    cat "$TMPDIR/callback-body" >&2
+    kill "$login_pid" 2>/dev/null || true
+    exit 1
+  fi
+  if ! ${pkgs.gnugrep}/bin/grep -q 'state mismatch' "$TMPDIR/callback-body"; then
+    echo "callback response body missing the expected state-mismatch message:" >&2
+    cat "$TMPDIR/callback-body" >&2
+    kill "$login_pid" 2>/dev/null || true
+    exit 1
+  fi
+
+  # The rejected callback must settle the login promise: the CLI exits
+  # nonzero instead of waiting for the five-minute login timeout.
+  tries=0
+  while kill -0 "$login_pid" 2>/dev/null; do
+    tries=$((tries + 1))
+    if [ "$tries" -gt 30 ]; then
+      echo "logseq-cli login still running 30s after the rejected callback" >&2
+      cat "$TMPDIR/login-output" >&2
+      kill "$login_pid" 2>/dev/null || true
+      exit 1
+    fi
+    sleep 1
+  done
+  login_status=0
+  wait "$login_pid" || login_status=$?
+  if [ "$login_status" -eq 0 ]; then
+    echo "logseq-cli login exited 0 after a state-mismatch callback" >&2
+    cat "$TMPDIR/login-output" >&2
+    exit 1
+  fi
+  if ! ${pkgs.gnugrep}/bin/grep -Eq 'invalid-callback-state|state mismatch' "$TMPDIR/login-output"; then
+    echo "logseq-cli login output missing the state-mismatch error:" >&2
+    cat "$TMPDIR/login-output" >&2
+    exit 1
+  fi
+
+  touch $out
+''

--- a/modules/_packages/logseq-cli/build.nix
+++ b/modules/_packages/logseq-cli/build.nix
@@ -32,6 +32,14 @@ stdenv.mkDerivation {
   pname = "logseq-cli-built";
   inherit version src;
 
+  # Temporary upstream fixes; each patch header documents the bug and its
+  # removal condition. Only patches touching files compiled into the CLI
+  # belong here. The nightly desktop build applies the full patches/ set in
+  # .github/workflows/build-desktop.yml; keep the two apply sites in sync
+  # when adding or removing a CLI-relevant patch. Patching here (not in the
+  # source FOD) keeps cliSrcHash and the dependency FODs unchanged.
+  patches = [ ../../../patches/logseq-cli-auth-bind-ipv4-loopback.patch ];
+
   # keytar (db-worker OS-keychain access) ships no usable prebuilt for this Node
   # ABI, so its native addon is compiled from source with node-gyp (see the
   # "build keytar.node" step in buildPhase). That needs a C/C++ toolchain plus

--- a/modules/checks.nix
+++ b/modules/checks.nix
@@ -54,6 +54,11 @@
           inherit pkgs;
           inherit (logseqNightly) cli;
         };
+
+        logseq-cli-login-callback = import ./_checks/cli-login-callback.nix {
+          inherit pkgs;
+          inherit (logseqNightly) cli;
+        };
       };
     };
 }

--- a/patches/logseq-cli-auth-bind-ipv4-loopback.patch
+++ b/patches/logseq-cli-auth-bind-ipv4-loopback.patch
@@ -1,0 +1,53 @@
+Bind the CLI OAuth callback servers to the IPv4 loopback literal.
+
+logseq.cli.auth listens with (.listen server 8765 "localhost"). Node resolves
+the host with dns.lookup and binds only the first returned address, which is
+::1 on systems whose hosts file lists the IPv6 loopback first. Browsers with
+IPv6 DNS disabled (for example LibreWolf with network.dns.disableIPv6=true)
+resolve localhost to 127.0.0.1 only, get connection refused, and the login
+callback never reaches the CLI, which keeps waiting until the login timeout.
+
+Fix: bind 127.0.0.1 explicitly, following RFC 8252 section 8.3. Browsers that
+prefer ::1 fall back to the next loopback address on refusal, and the
+redirect URI keeps the "localhost" host registered with the Cognito client.
+
+Removal condition: drop this patch when upstream binds an explicit loopback
+literal (or dual-binds both families) in src/main/logseq/cli/auth.cljs. A
+failed strict apply in the nightly build or the CLI build is the drift signal.
+
+diff --git a/src/main/logseq/cli/auth.cljs b/src/main/logseq/cli/auth.cljs
+index d901975..33927c6 100644
+--- a/src/main/logseq/cli/auth.cljs
++++ b/src/main/logseq/cli/auth.cljs
+@@ -17,6 +17,13 @@
+ (def ^:private logout-complete-path "/logout-complete")
+ (def ^:private callback-host "localhost")
+ (def ^:private callback-port 8765)
++;; Bind the loopback IP literal instead of "localhost": node binds only the
++;; first address the resolver returns (often ::1), while browsers with IPv6
++;; disabled connect to 127.0.0.1 only, so the OAuth redirect can target an
++;; address family the server never bound. RFC 8252 section 8.3 recommends
++;; loopback IP literals. The redirect URI keeps the "localhost" host that
++;; the Cognito app client registers.
++(def ^:private callback-bind-address "127.0.0.1")
+ (def ^:private auth-provider "cognito")
+ (def ^:private default-scope "email openid phone")
+ (def ^:private token-endpoint-path "/oauth2/token")
+@@ -258,7 +265,7 @@
+                               (reject (ex-info "failed to start login callback server"
+                                                {:code :login-callback-server-start-failed}
+                                                error))))
+-       (.listen server callback-port callback-host
++       (.listen server callback-port callback-bind-address
+                 (fn []
+                   (let [address (.address server)
+                         port (.-port address)
+@@ -308,7 +315,7 @@
+                               (reject (ex-info "failed to start logout callback server"
+                                                {:code :logout-callback-server-start-failed}
+                                                error))))
+-       (.listen server callback-port callback-host
++       (.listen server callback-port callback-bind-address
+                 (fn []
+                   (resolve {:logout-uri (logout-complete-uri)
+                             :wait! (fn []

--- a/patches/logseq-header-hoist-conditional-use-sub.patch
+++ b/patches/logseq-header-hoist-conditional-use-sub.patch
@@ -1,0 +1,40 @@
+Hoist a conditional state/use-sub hook out of the header conditional.
+
+Upstream commit d185ea58 ("refactor: replace Rum with HSX", logseq/logseq#12748)
+converted state subscriptions from Rum reactivity to React hooks. The header
+kept calling (state/use-sub :electron/server) inside
+(when (state/feature-http-server-enabled?) ...). That condition reads
+non-reactive localStorage and flips mid-session (settings auto-enable it when
+MCP is toggled on), so the next header re-render runs one extra hook and React
+throws error #310 ("Rendered more hooks than during the previous render"),
+which the error boundary turns into a dead UI. Login state churn re-renders
+the header, so the crash surfaces at login.
+
+Fix: subscribe unconditionally in the component let block and use the value
+inside the conditional, per the Rules of Hooks.
+
+Removal condition: drop this patch when upstream hoists or otherwise fixes the
+conditional hook in src/main/frontend/components/header.cljs. A failed strict
+apply in the nightly build is the drift signal.
+
+diff --git a/src/main/frontend/components/header.cljs b/src/main/frontend/components/header.cljs
+index 394e3c3..a7074f7 100644
+--- a/src/main/frontend/components/header.cljs
++++ b/src/main/frontend/components/header.cljs
+@@ -395,6 +395,7 @@
+   (let [electron-mac? (and util/mac? (util/electron?))
+         rtc-graphs (state/use-sub :rtc/graphs)
+         default-home-page (state/use-sub-default-home-page)
++        electron-server (state/use-sub :electron/server)
+         left-menu (left-menu-button {:on-click (fn []
+                                                  (state/set-left-sidebar-open!
+                                                   (not (:ui/left-sidebar-open? @state/state))))})
+@@ -470,7 +471,7 @@
+           (plugins/updates-notifications)])
+ 
+        (when (state/feature-http-server-enabled?)
+-         (server/server-indicator (state/use-sub :electron/server)))
++         (server/server-indicator electron-server))
+ 
+        (when (util/electron?)
+          (back-and-forward))


### PR DESCRIPTION
## Summary

The first nightly after #31 (manifest bump 757c93a) moved upstream `logseq/logseq` forward by 37 commits at once (2026-05-28 to 2026-06-04, pinned rev `0a27a795`). Two of those upstream commits regress login flows. This PR carries both fixes as strict-apply patches under `patches/` until upstream lands them, and adds a hermetic regression check for the CLI path.

| Symptom | Upstream root cause | Patch |
| --- | --- | --- |
| Desktop crashes at login with React error #310 at `header.cljs:473` | `d185ea58` ("refactor: replace Rum with HSX", logseq/logseq#12748) left `(state/use-sub :electron/server)` inside `(when (state/feature-http-server-enabled?) ...)`. The flag is non-reactive localStorage and flips mid-session (the MCP toggle auto-enables it in `settings.cljs`), so the next header re-render runs one extra hook and the error boundary blanks the UI. | `patches/logseq-header-hoist-conditional-use-sub.patch` hoists the hook into the unconditional component `let`. |
| `logseq login` callback never completes; CLI sits on `[::1]:8765` until the 5 minute timeout | The relocated CLI (2.0.1-alpha) binds `(.listen server 8765 "localhost")`. Node binds only the first resolved address (`::1` when the hosts file lists the IPv6 loopback first). Browsers with IPv6 DNS disabled (LibreWolf `network.dns.disableIPv6=true`) resolve `localhost` to `127.0.0.1` only and get connection refused. | `patches/logseq-cli-auth-bind-ipv4-loopback.patch` binds `127.0.0.1` per RFC 8252 section 8.3; the redirect URI keeps the Cognito-registered `localhost` host. |

## Mechanism

- `.github/workflows/build-desktop.yml` strict-applies every `patches/logseq-*.patch` right after cloning upstream, so the desktop tarballs and the bundled `static/js/logseq-cli.js` ship the fixes.
- `modules/_packages/logseq-cli/build.nix` lists the auth patch in `patches`; patching the build derivation (not the source FOD) keeps `cliSrcHash`, `cliPnpmDepsHash`, and `cliCljDepsHash` unchanged, so the FODs stay cache-hot.
- Each patch header documents the bug and its removal condition. A failed strict apply (nightly or CLI build) means upstream fixed or moved the code: delete or regenerate the patch in the same change.
- New check `logseq-cli-login-callback`: stubs the browser opener, runs `logseq-cli login`, curls `http://127.0.0.1:8765/auth/callback` with a mismatched state, and asserts HTTP 400 plus a nonzero CLI exit. The state mismatch keeps the probe offline, so it is sandbox-hermetic. An unpatched CLI fails the probe with connection refused.

## Verification on the reporting machine

Patched CLI, same environment that reproduced the bug (`getent hosts localhost` returns `::1` first; default browser is LibreWolf with IPv6 DNS disabled):

```
LISTEN 0  511  127.0.0.1:8765  0.0.0.0:*          (was [::1]:8765)
HTTP 400 Login failed due to state mismatch. ...  (was connection refused)
CLI exit 1: Error (invalid-callback-state)        (was a 5 minute hang)
```

## Validation

```
git apply --check (both patches, upstream checkout at 0a27a795)
nix fmt
nix flake show --all-systems --accept-flake-config
nix build .#checks.x86_64-linux.logseq-cli-login-callback
nix build .#checks.x86_64-linux.logseq-cli-help
nix build .#checks.x86_64-linux.logseq-cli
nix develop -c pre-commit run --all-files
nix develop -c pre-commit run gitleaks --hook-stage manual --all-files
```

## After merge

- The CLI fix is live for `nix build .#logseq-cli` consumers immediately.
- The desktop fix ships with the next nightly (scheduled run, or `gh workflow run nightly.yml`); the prebuilt tarballs referenced by the current manifest remain broken until then.

## Upstream report (ready to file against logseq/logseq)

<details>
<summary>Draft issue text</summary>

Title: Conditional state/use-sub hooks crash after the HSX migration; CLI OAuth callback binds a single loopback family

1. `src/main/frontend/components/header.cljs` calls `(state/use-sub :electron/server)` inside `(when (state/feature-http-server-enabled?) ...)`. `feature-http-server-enabled?` reads non-reactive localStorage and `settings.cljs` auto-enables it when MCP is toggled on, so the hook count changes between renders of `header-aux` and React throws error #310 at login (login state churn re-renders the header). Two more conditional hook sites from the same migration look latent: `src/main/frontend/components/page.cljs` line 211 (`use-sub-config` behind `(when (and today? (not sidebar?)))`) and `src/main/frontend/components/left_sidebar.cljs` line 273 (`use-sub :srs/cards-due-count` behind `enable-flashcards?`).
2. `src/main/logseq/cli/auth.cljs` listens with `(.listen server 8765 "localhost")`. Node binds only the first address `dns.lookup` returns (`::1` on hosts whose `/etc/hosts` lists the IPv6 loopback first), while browsers with IPv6 DNS disabled resolve `localhost` to `127.0.0.1` only, so the OAuth redirect gets connection refused and `logseq login` hangs until the timeout. RFC 8252 section 8.3 recommends binding the loopback IP literal (or both families); the redirect URI can keep the `localhost` host.

</details>
