### PR TITLE
feat(ci): add dispatchable pr-build workflow for arbitrary repo/PR test builds

### DIFF
--- a/.github/actions/publish-release-assets/action.yml
+++ b/.github/actions/publish-release-assets/action.yml
@@ -1,22 +1,37 @@
 name: Publish release assets
-description: Idempotently (re)create a GitHub release with assets
+description: >-
+  Idempotently (re)create a GitHub release with assets. Defaults target
+  disposable test releases: inputs fall back to the RELEASE_* env vars
+  exported by resolve-build-metadata, so a bare invocation after that action
+  needs no inputs at all. The nightly publish flow overrides them explicitly.
 inputs:
   tag:
-    description: Release tag to create or recreate
-    required: true
-  title:
-    description: Release title shown in the GitHub UI
-    required: true
-  notes-file:
-    description: Path to a file whose contents become the release body
-    required: true
-  target:
-    description: Commit SHA or branch name that the release tag points at
-    required: true
-  prerelease:
-    description: Mark the release as a prerelease
+    description: >-
+      Release tag to create or recreate. Falls back to RELEASE_TAG (exported
+      by resolve-build-metadata), then to a generated test-<date>-<run id>.
     required: false
-    default: "false"
+    default: ""
+  title:
+    description: Release title shown in the GitHub UI. Defaults to the tag.
+    required: false
+    default: ""
+  notes-file:
+    description: >-
+      Path to a file whose contents become the release body. Falls back to
+      RELEASE_NOTES (exported by resolve-build-metadata), then to an empty
+      body.
+    required: false
+    default: ""
+  target:
+    description: >-
+      Commit SHA or branch name that the release tag points at. Defaults to
+      the commit the workflow runs on.
+    required: false
+    default: ${{ github.sha }}
+  prerelease:
+    description: Mark the release as a prerelease (the nightly flow sets false)
+    required: false
+    default: "true"
   mark-latest:
     description: Mark the release as the latest release (default false, passes --latest=false)
     required: false
@@ -24,10 +39,14 @@ inputs:
   cleanup-tag:
     description: Delete the tag when deleting the release (nightly keeps tags; test flows delete them)
     required: false
-    default: "false"
+    default: "true"
   assets:
-    description: Newline-separated asset paths to attach to the release
-    required: true
+    description: >-
+      Newline-separated asset paths to attach to the release. Falls back to
+      RELEASE_ASSETS (exported by resolve-build-metadata). Fails when no
+      asset paths resolve.
+    required: false
+    default: ""
 outputs:
   release-url:
     value: "${{ steps.create.outputs.release-url }}"
@@ -48,13 +67,28 @@ runs:
       run: |
         set -euo pipefail
         : "${GH_TOKEN:?GH_TOKEN must be set in the calling step env}"
+        # Inputs fall back to the RELEASE_* env handoff from resolve-build-metadata.
+        tag="${TAG:-${RELEASE_TAG:-}}"
+        [ -n "$tag" ] || tag="test-$(date -u +%Y%m%d)-${GITHUB_RUN_ID}"
+        title="${TITLE:-$tag}"
+        notes_file="${NOTES_FILE:-${RELEASE_NOTES:-}}"
+        assets="${ASSETS:-${RELEASE_ASSETS:-}}"
+        mapfile -t asset_paths < <(printf '%s\n' "$assets" | tr -d '\r' | sed '/^$/d')
+        if [ "${#asset_paths[@]}" -eq 0 ]; then
+          echo "No release assets resolved: pass assets, or run resolve-build-metadata first so RELEASE_ASSETS is exported" >&2
+          exit 1
+        fi
         delete_args=(-y)
         [ "$CLEANUP_TAG" = "true" ] && delete_args+=(--cleanup-tag)
         # Idempotent on a same-run retry.
-        gh release delete "$TAG" "${delete_args[@]}" || true
-        mapfile -t asset_paths < <(printf '%s\n' "$ASSETS" | tr -d '\r' | sed '/^$/d')
-        args=(--title "$TITLE" --notes-file "$NOTES_FILE" --target "$TARGET")
+        gh release delete "$tag" "${delete_args[@]}" || true
+        args=(--title "$title" --target "$TARGET")
+        if [ -n "$notes_file" ]; then
+          args+=(--notes-file "$notes_file")
+        else
+          args+=(--notes "")
+        fi
         [ "$PRERELEASE" = "true" ] && args+=(--prerelease)
         [ "$MARK_LATEST" = "true" ] || args+=(--latest=false)
-        url="$(gh release create "$TAG" "${asset_paths[@]}" "${args[@]}")"
+        url="$(gh release create "$tag" "${asset_paths[@]}" "${args[@]}")"
         echo "release-url=${url}" >>"$GITHUB_OUTPUT"

--- a/.github/actions/publish-release-assets/action.yml
+++ b/.github/actions/publish-release-assets/action.yml
@@ -52,7 +52,7 @@ runs:
         [ "$CLEANUP_TAG" = "true" ] && delete_args+=(--cleanup-tag)
         # Idempotent on a same-run retry.
         gh release delete "$TAG" "${delete_args[@]}" || true
-        mapfile -t asset_paths < <(printf '%s\n' "$ASSETS" | sed '/^$/d')
+        mapfile -t asset_paths < <(printf '%s\n' "$ASSETS" | tr -d '\r' | sed '/^$/d')
         args=(--title "$TITLE" --notes-file "$NOTES_FILE" --target "$TARGET")
         [ "$PRERELEASE" = "true" ] && args+=(--prerelease)
         [ "$MARK_LATEST" = "true" ] || args+=(--latest=false)

--- a/.github/actions/publish-release-assets/action.yml
+++ b/.github/actions/publish-release-assets/action.yml
@@ -1,0 +1,60 @@
+name: Publish release assets
+description: Idempotently (re)create a GitHub release with assets
+inputs:
+  tag:
+    description: Release tag to create or recreate
+    required: true
+  title:
+    description: Release title shown in the GitHub UI
+    required: true
+  notes-file:
+    description: Path to a file whose contents become the release body
+    required: true
+  target:
+    description: Commit SHA or branch name that the release tag points at
+    required: true
+  prerelease:
+    description: Mark the release as a prerelease
+    required: false
+    default: "false"
+  mark-latest:
+    description: Mark the release as the latest release (default false, passes --latest=false)
+    required: false
+    default: "false"
+  cleanup-tag:
+    description: Delete the tag when deleting the release (nightly keeps tags; test flows delete them)
+    required: false
+    default: "false"
+  assets:
+    description: Newline-separated asset paths to attach to the release
+    required: true
+outputs:
+  release-url:
+    value: "${{ steps.create.outputs.release-url }}"
+runs:
+  using: composite
+  steps:
+    - id: create
+      shell: bash
+      env:
+        TAG: ${{ inputs.tag }}
+        TITLE: ${{ inputs.title }}
+        NOTES_FILE: ${{ inputs.notes-file }}
+        TARGET: ${{ inputs.target }}
+        PRERELEASE: ${{ inputs.prerelease }}
+        MARK_LATEST: ${{ inputs.mark-latest }}
+        CLEANUP_TAG: ${{ inputs.cleanup-tag }}
+        ASSETS: ${{ inputs.assets }}
+      run: |
+        set -euo pipefail
+        : "${GH_TOKEN:?GH_TOKEN must be set in the calling step env}"
+        delete_args=(-y)
+        [ "$CLEANUP_TAG" = "true" ] && delete_args+=(--cleanup-tag)
+        # Idempotent on a same-run retry.
+        gh release delete "$TAG" "${delete_args[@]}" || true
+        mapfile -t asset_paths < <(printf '%s\n' "$ASSETS" | sed '/^$/d')
+        args=(--title "$TITLE" --notes-file "$NOTES_FILE" --target "$TARGET")
+        [ "$PRERELEASE" = "true" ] && args+=(--prerelease)
+        [ "$MARK_LATEST" = "true" ] || args+=(--latest=false)
+        url="$(gh release create "$TAG" "${asset_paths[@]}" "${args[@]}")"
+        echo "release-url=${url}" >>"$GITHUB_OUTPUT"

--- a/.github/actions/resolve-build-metadata/action.yml
+++ b/.github/actions/resolve-build-metadata/action.yml
@@ -59,7 +59,12 @@ runs:
         notes="$(find_one release-notes.md release-notes)"
         read_meta_value() {
           local key="$1"
-          grep -E -m 1 "^${key}=" "$meta" | cut -d= -f2- | tr -d '\r\n'
+          local line
+          if ! line="$(grep -E -m 1 "^${key}=" "$meta")"; then
+            echo "Missing required key in meta.txt: ${key}" >&2
+            exit 1
+          fi
+          printf '%s' "${line#*=}" | tr -d '\r\n'
         }
         version="$(read_meta_value version)"
         revision="$(read_meta_value revision)"
@@ -83,7 +88,8 @@ runs:
           tarball="$(find_one "$glob" "$system tarball")"
           hash_file="$(find_one "$hashname" "$system hash")"
           url="https://github.com/${REPO}/releases/download/${tag}/$(basename "$tarball")"
-          hash="$(tr -d '\r' <"$hash_file")"
+          hash="$(tr -d '\r\n' <"$hash_file")"
+          [[ "$hash" =~ ^sha256-[A-Za-z0-9+/=]+$ ]] || { echo "Invalid sha256 hash in $hash_file: $hash" >&2; exit 1; }
           {
             echo "${tarvar}=${tarball}"
             echo "${urlvar}=${url}"

--- a/.github/actions/resolve-build-metadata/action.yml
+++ b/.github/actions/resolve-build-metadata/action.yml
@@ -69,7 +69,7 @@ runs:
         version="$(read_meta_value version)"
         revision="$(read_meta_value revision)"
         datestring="$(read_meta_value datestring)"
-        [[ -n "$version" ]] || { echo "Invalid version in meta.txt: empty" >&2; exit 1; }
+        [[ "$version" =~ ^[A-Za-z0-9._+-]+$ ]] || { echo "Invalid version in meta.txt: ${version}" >&2; exit 1; }
         [[ "$revision" =~ ^[0-9a-f]{40}$ ]] || { echo "Invalid revision in meta.txt: ${revision}" >&2; exit 1; }
         [[ "$datestring" =~ ^[0-9]{8}$ ]] || { echo "Invalid datestring in meta.txt: ${datestring}" >&2; exit 1; }
         tag="${TAG_PREFIX}${datestring}${TAG_SUFFIX}"

--- a/.github/actions/resolve-build-metadata/action.yml
+++ b/.github/actions/resolve-build-metadata/action.yml
@@ -1,0 +1,103 @@
+name: Resolve build metadata
+description: Map downloaded build artifacts to release env vars and outputs
+inputs:
+  systems:
+    description: CSV of nix systems to require (x86_64-linux,aarch64-linux,aarch64-darwin)
+    required: true
+  repo:
+    description: owner/repo hosting the release download URLs
+    required: true
+  tag-prefix:
+    description: Release tag prefix (tag = <prefix><datestring><suffix>)
+    required: true
+  tag-suffix:
+    required: false
+    default: ""
+  builds-dir:
+    required: false
+    default: builds
+outputs:
+  version:
+    value: "${{ steps.resolve.outputs.version }}"
+  revision:
+    value: "${{ steps.resolve.outputs.revision }}"
+  tag:
+    value: "${{ steps.resolve.outputs.tag }}"
+  assets-json:
+    value: "${{ steps.resolve.outputs.assets-json }}"
+runs:
+  using: composite
+  steps:
+    - id: resolve
+      shell: bash
+      env:
+        SYSTEMS: ${{ inputs.systems }}
+        REPO: ${{ inputs.repo }}
+        TAG_PREFIX: ${{ inputs.tag-prefix }}
+        TAG_SUFFIX: ${{ inputs.tag-suffix }}
+        BUILDS_DIR: ${{ inputs.builds-dir }}
+      run: |
+        set -euo pipefail
+        find_one() {
+          local pattern="$1" label="$2"
+          local hits
+          mapfile -t hits < <(find "$BUILDS_DIR" -name "$pattern" -print | sort)
+          case "${#hits[@]}" in
+            0)
+              echo "Required artifact missing: $label ($pattern)" >&2
+              exit 1
+              ;;
+            1) printf '%s' "${hits[0]}" ;;
+            *)
+              echo "Ambiguous artifact for $label ($pattern): ${hits[*]}" >&2
+              exit 1
+              ;;
+          esac
+        }
+        # meta.txt and release-notes.md come from the single build-metadata artifact, so exactly one match is expected.
+        meta="$(find_one meta.txt meta)"
+        notes="$(find_one release-notes.md release-notes)"
+        version="$(grep -E '^version=' "$meta" | cut -d= -f2-)"
+        revision="$(grep -E '^revision=' "$meta" | cut -d= -f2-)"
+        datestring="$(grep -E '^datestring=' "$meta" | cut -d= -f2-)"
+        tag="${TAG_PREFIX}${datestring}${TAG_SUFFIX}"
+        {
+          echo "LOGSEQ_VERSION=${version}"
+          echo "LOGSEQ_REV=${revision}"
+          echo "BUILD_REVISION=${revision}"
+          echo "NIGHTLY_TAG=${tag}"
+          echo "RELEASE_TAG=${tag}"
+          echo "RELEASE_NOTES=${notes}"
+        } >>"$GITHUB_ENV"
+        assets_json="[]"
+        emit_system() {
+          local system="$1" glob="$2" hashname="$3" tarvar="$4" urlvar="$5" shavar="$6"
+          local tarball hash_file url hash
+          tarball="$(find_one "$glob" "$system tarball")"
+          hash_file="$(find_one "$hashname" "$system hash")"
+          url="https://github.com/${REPO}/releases/download/${tag}/$(basename "$tarball")"
+          hash="$(cat "$hash_file")"
+          {
+            echo "${tarvar}=${tarball}"
+            echo "${urlvar}=${url}"
+            echo "${shavar}=${hash}"
+          } >>"$GITHUB_ENV"
+          assets_json="$(jq -c --arg s "$system" --arg u "$url" \
+            --arg h "$hash" --arg t "$tarball" \
+            '. + [{system:$s,url:$u,sha256:$h,tarball:$t}]' <<<"$assets_json")"
+        }
+        IFS=',' read -ra wanted <<<"$SYSTEMS"
+        for system in "${wanted[@]}"; do
+          case "$system" in
+            x86_64-linux) emit_system "$system" 'logseq-linux-x64-*.tar.gz' hash-x64.txt X64_TARBALL ASSET_URL_X86_64 ASSET_SHA256_X86_64 ;;
+            aarch64-linux) emit_system "$system" 'logseq-linux-arm64-*.tar.gz' hash-arm64.txt ARM64_TARBALL ASSET_URL_AARCH64 ASSET_SHA256_AARCH64 ;;
+            aarch64-darwin) emit_system "$system" 'logseq-darwin-arm64-*.tar.gz' hash-darwin-arm64.txt DARWIN_ARM64_TARBALL ASSET_URL_AARCH64_DARWIN ASSET_SHA256_AARCH64_DARWIN ;;
+            *) echo "Unknown system: $system" >&2; exit 1 ;;
+          esac
+        done
+        {
+          echo "version=${version}"
+          echo "revision=${revision}"
+          echo "tag=${tag}"
+          echo "assets-json=${assets_json}"
+        } >>"$GITHUB_OUTPUT"

--- a/.github/actions/resolve-build-metadata/action.yml
+++ b/.github/actions/resolve-build-metadata/action.yml
@@ -57,9 +57,9 @@ runs:
         # meta.txt and release-notes.md come from the single build-metadata artifact, so exactly one match is expected.
         meta="$(find_one meta.txt meta)"
         notes="$(find_one release-notes.md release-notes)"
-        version="$(grep -E '^version=' "$meta" | cut -d= -f2-)"
-        revision="$(grep -E '^revision=' "$meta" | cut -d= -f2-)"
-        datestring="$(grep -E '^datestring=' "$meta" | cut -d= -f2-)"
+        version="$(grep -E '^version=' "$meta" | cut -d= -f2- | tr -d '\r')"
+        revision="$(grep -E '^revision=' "$meta" | cut -d= -f2- | tr -d '\r')"
+        datestring="$(grep -E '^datestring=' "$meta" | cut -d= -f2- | tr -d '\r')"
         tag="${TAG_PREFIX}${datestring}${TAG_SUFFIX}"
         {
           echo "LOGSEQ_VERSION=${version}"
@@ -76,7 +76,7 @@ runs:
           tarball="$(find_one "$glob" "$system tarball")"
           hash_file="$(find_one "$hashname" "$system hash")"
           url="https://github.com/${REPO}/releases/download/${tag}/$(basename "$tarball")"
-          hash="$(cat "$hash_file")"
+          hash="$(tr -d '\r' <"$hash_file")"
           {
             echo "${tarvar}=${tarball}"
             echo "${urlvar}=${url}"
@@ -86,7 +86,7 @@ runs:
             --arg h "$hash" --arg t "$tarball" \
             '. + [{system:$s,url:$u,sha256:$h,tarball:$t}]' <<<"$assets_json")"
         }
-        IFS=',' read -ra wanted <<<"$SYSTEMS"
+        IFS=',' read -ra wanted <<<"${SYSTEMS//[[:space:]]/}"
         for system in "${wanted[@]}"; do
           case "$system" in
             x86_64-linux) emit_system "$system" 'logseq-linux-x64-*.tar.gz' hash-x64.txt X64_TARBALL ASSET_URL_X86_64 ASSET_SHA256_X86_64 ;;

--- a/.github/actions/resolve-build-metadata/action.yml
+++ b/.github/actions/resolve-build-metadata/action.yml
@@ -1,19 +1,33 @@
 name: Resolve build metadata
-description: Map downloaded build artifacts to release env vars and outputs
+description: >-
+  Map downloaded build artifacts to release env vars and outputs. Exports
+  RELEASE_TAG, RELEASE_NOTES, RELEASE_ASSETS, and per-system tarball, URL,
+  and SRI hash env vars; publish-release-assets consumes them as defaults.
 inputs:
   systems:
-    description: CSV of nix systems to require (x86_64-linux,aarch64-linux,aarch64-darwin)
-    required: true
-  repo:
-    description: owner/repo hosting the release download URLs
-    required: true
-  tag-prefix:
-    description: Release tag prefix (tag = <prefix><datestring><suffix>)
-    required: true
-  tag-suffix:
+    description: >-
+      CSV of nix systems to require. Defaults to all supported systems; pass
+      a computed subset when arch legs are optional.
     required: false
-    default: ""
+    default: x86_64-linux,aarch64-linux,aarch64-darwin
+  repo:
+    description: >-
+      owner/repo that will host the release the asset download URLs point at.
+      Defaults to the repository running the workflow.
+    required: false
+    default: ${{ github.repository }}
+  tag-prefix:
+    description: >-
+      Release tag prefix (tag = <prefix><datestring><suffix>). The defaults
+      yield a disposable test tag like test-20260606-1234567890.
+    required: false
+    default: test-
+  tag-suffix:
+    description: Release tag suffix appended after the datestring.
+    required: false
+    default: "-${{ github.run_id }}"
   builds-dir:
+    description: Directory holding the downloaded build artifacts.
     required: false
     default: builds
 outputs:
@@ -38,6 +52,11 @@ runs:
         BUILDS_DIR: ${{ inputs.builds-dir }}
       run: |
         set -euo pipefail
+        systems_csv="${SYSTEMS//[[:space:]]/}"
+        if [ -z "$systems_csv" ]; then
+          echo "systems must name at least one nix system" >&2
+          exit 1
+        fi
         find_one() {
           local pattern="$1" label="$2"
           local hits
@@ -82,6 +101,7 @@ runs:
           echo "RELEASE_NOTES=${notes}"
         } >>"$GITHUB_ENV"
         assets_json="[]"
+        present_tarballs=()
         emit_system() {
           local system="$1" glob="$2" hashname="$3" tarvar="$4" urlvar="$5" shavar="$6"
           local tarball hash_file url hash
@@ -95,11 +115,12 @@ runs:
             echo "${urlvar}=${url}"
             echo "${shavar}=${hash}"
           } >>"$GITHUB_ENV"
+          present_tarballs+=("$tarball")
           assets_json="$(jq -c --arg s "$system" --arg u "$url" \
             --arg h "$hash" --arg t "$tarball" \
             '. + [{system:$s,url:$u,sha256:$h,tarball:$t}]' <<<"$assets_json")"
         }
-        IFS=',' read -ra wanted <<<"${SYSTEMS//[[:space:]]/}"
+        IFS=',' read -ra wanted <<<"$systems_csv"
         for system in "${wanted[@]}"; do
           case "$system" in
             x86_64-linux) emit_system "$system" 'logseq-linux-x64-*.tar.gz' hash-x64.txt X64_TARBALL ASSET_URL_X86_64 ASSET_SHA256_X86_64 ;;
@@ -108,6 +129,12 @@ runs:
             *) echo "Unknown system: $system" >&2; exit 1 ;;
           esac
         done
+        # Newline-joined tarball list; publish-release-assets uses it as the default asset set.
+        {
+          echo "RELEASE_ASSETS<<EOF_RELEASE_ASSETS"
+          printf '%s\n' "${present_tarballs[@]}"
+          echo "EOF_RELEASE_ASSETS"
+        } >>"$GITHUB_ENV"
         {
           echo "version=${version}"
           echo "revision=${revision}"

--- a/.github/actions/resolve-build-metadata/action.yml
+++ b/.github/actions/resolve-build-metadata/action.yml
@@ -57,9 +57,16 @@ runs:
         # meta.txt and release-notes.md come from the single build-metadata artifact, so exactly one match is expected.
         meta="$(find_one meta.txt meta)"
         notes="$(find_one release-notes.md release-notes)"
-        version="$(grep -E '^version=' "$meta" | cut -d= -f2- | tr -d '\r')"
-        revision="$(grep -E '^revision=' "$meta" | cut -d= -f2- | tr -d '\r')"
-        datestring="$(grep -E '^datestring=' "$meta" | cut -d= -f2- | tr -d '\r')"
+        read_meta_value() {
+          local key="$1"
+          grep -E -m 1 "^${key}=" "$meta" | cut -d= -f2- | tr -d '\r\n'
+        }
+        version="$(read_meta_value version)"
+        revision="$(read_meta_value revision)"
+        datestring="$(read_meta_value datestring)"
+        [[ -n "$version" ]] || { echo "Invalid version in meta.txt: empty" >&2; exit 1; }
+        [[ "$revision" =~ ^[0-9a-f]{40}$ ]] || { echo "Invalid revision in meta.txt: ${revision}" >&2; exit 1; }
+        [[ "$datestring" =~ ^[0-9]{8}$ ]] || { echo "Invalid datestring in meta.txt: ${datestring}" >&2; exit 1; }
         tag="${TAG_PREFIX}${datestring}${TAG_SUFFIX}"
         {
           echo "LOGSEQ_VERSION=${version}"

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -59,6 +59,7 @@ jobs:
     outputs:
       rev: ${{ steps.resolve.outputs.rev }}
       repo: ${{ steps.resolve.outputs.repo }}
+      matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
       - name: Resolve source revision
         id: resolve
@@ -93,28 +94,50 @@ jobs:
           echo "rev=${rev}" >>"$GITHUB_OUTPUT"
           echo "repo=${LOGSEQ_REPO}" >>"$GITHUB_OUTPUT"
 
+      - name: Select build matrix
+        id: matrix
+        env:
+          BUILD_X86_64_LINUX: ${{ inputs.build_x86_64_linux }}
+          BUILD_AARCH64_LINUX: ${{ inputs.build_aarch64_linux }}
+          BUILD_AARCH64_DARWIN: ${{ inputs.build_aarch64_darwin }}
+        run: |
+          set -euo pipefail
+          matrix="$(jq -cn \
+            --argjson x64 "$BUILD_X86_64_LINUX" \
+            --argjson arm64 "$BUILD_AARCH64_LINUX" \
+            --argjson darwin "$BUILD_AARCH64_DARWIN" \
+            '[
+              if $x64 then {
+                os: "linux",
+                arch: "x64",
+                runner: "ubuntu-24.04",
+                nix_system: "x86_64-linux"
+              } else empty end,
+              if $arm64 then {
+                os: "linux",
+                arch: "arm64",
+                runner: "ubuntu-24.04-arm",
+                nix_system: "aarch64-linux"
+              } else empty end,
+              if $darwin then {
+                os: "darwin",
+                arch: "arm64",
+                runner: "macos-26",
+                nix_system: "aarch64-darwin"
+              } else empty end
+            ] as $include
+            | if ($include | length) == 0 then
+                error("at least one build system must be selected")
+              else
+                {include: $include}
+              end')"
+          echo "matrix=${matrix}" >>"$GITHUB_OUTPUT"
+
   build:
     needs: resolve-revision
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - os: linux
-            arch: x64
-            runner: ubuntu-24.04
-            nix_system: x86_64-linux
-          - os: linux
-            arch: arm64
-            runner: ubuntu-24.04-arm
-            nix_system: aarch64-linux
-          - os: darwin
-            arch: arm64
-            runner: macos-26
-            nix_system: aarch64-darwin
-        exclude:
-          - nix_system: ${{ !inputs.build_x86_64_linux && 'x86_64-linux' || '' }}
-          - nix_system: ${{ !inputs.build_aarch64_linux && 'aarch64-linux' || '' }}
-          - nix_system: ${{ !inputs.build_aarch64_darwin && 'aarch64-darwin' || '' }}
+      matrix: ${{ fromJSON(needs.resolve-revision.outputs.matrix) }}
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -235,7 +235,7 @@ jobs:
 
       - name: Determine nightly version
         id: version
-        run: echo "value=$(node ./scripts/get-pkg-version.js nightly)" >> "$GITHUB_OUTPUT"
+        run: echo "value=$(node ./scripts/get-pkg-version.js nightly | tr -d '\r\n')" >>"$GITHUB_OUTPUT"
         working-directory: logseq-src
 
       - name: Update Nightly APP Version
@@ -316,7 +316,9 @@ jobs:
         working-directory: logseq-src/static
 
       - name: Save VERSION file
-        run: echo "${{ steps.version.outputs.value }}" > ./VERSION
+        env:
+          NIGHTLY_VERSION: ${{ steps.version.outputs.value }}
+        run: printf '%s\n' "$NIGHTLY_VERSION" >./VERSION
         working-directory: logseq-src/static
 
       - name: Verify Darwin Electron scripts
@@ -370,10 +372,12 @@ jobs:
 
       - name: Create tarball artifact
         working-directory: logseq-src/static
+        env:
+          NIGHTLY_VERSION: ${{ steps.version.outputs.value }}
         run: |
           set -euo pipefail
           mkdir -p out
-          version="${{ steps.version.outputs.value }}"
+          version="$NIGHTLY_VERSION"
           case "${{ matrix.os }}:${{ matrix.arch }}" in
             linux:*)
               src_dir="$(find dist -maxdepth 1 -type d -name 'linux*-unpacked' | head -1)"

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -8,10 +8,35 @@ on:
   workflow_call:
     inputs:
       logseq_branch:
-        description: "Logseq branch to build"
+        description: "Logseq branch to build (legacy alias; ignored when logseq_ref is set)"
         required: false
         type: string
         default: master
+      logseq_repo:
+        description: "GitHub repository (owner/repo) to build from"
+        required: false
+        type: string
+        default: logseq/logseq
+      logseq_ref:
+        description: "Branch, tag, 40-char SHA, or refs/pull/N/head; wins over logseq_branch when non-empty"
+        required: false
+        type: string
+        default: ""
+      build_x86_64_linux:
+        description: "Build the x86_64-linux matrix leg"
+        required: false
+        type: boolean
+        default: true
+      build_aarch64_linux:
+        description: "Build the aarch64-linux matrix leg"
+        required: false
+        type: boolean
+        default: true
+      build_aarch64_darwin:
+        description: "Build the aarch64-darwin matrix leg"
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -25,18 +50,43 @@ env:
 jobs:
   resolve-revision:
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
     outputs:
       rev: ${{ steps.resolve.outputs.rev }}
+      repo: ${{ steps.resolve.outputs.repo }}
     steps:
-      - name: Resolve upstream revision
+      - name: Resolve source revision
         id: resolve
         env:
-          LOGSEQ_BRANCH: ${{ inputs.logseq_branch }}
+          LOGSEQ_REPO: ${{ inputs.logseq_repo }}
+          LOGSEQ_REF: ${{ inputs.logseq_ref != '' && inputs.logseq_ref || inputs.logseq_branch }}
         run: |
           set -euo pipefail
-          rev="$(git ls-remote https://github.com/logseq/logseq.git "refs/heads/${LOGSEQ_BRANCH}" | head -1 | cut -f1)"
-          test -n "$rev" || { echo "Could not resolve refs/heads/${LOGSEQ_BRANCH}" >&2; exit 1; }
+          # Reject anything that could turn into an arbitrary clone URL.
+          if [[ ! "$LOGSEQ_REPO" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+            echo "logseq_repo must be OWNER/REPO, got: $LOGSEQ_REPO" >&2
+            exit 1
+          fi
+          if [[ "$LOGSEQ_REF" =~ ^[0-9a-f]{40}$ ]]; then
+            rev="$LOGSEQ_REF"
+          else
+            remote="https://github.com/${LOGSEQ_REPO}.git"
+            rev=""
+            # Order matters: branch wins over tag; X^{} peels annotated tags to
+            # the commit; the literal pattern covers refs/pull/N/head.
+            # A ref absent as a branch falls through to tags, then the literal
+            # (so a mistyped branch name that matches a tag resolves to the tag).
+            for pattern in "refs/heads/${LOGSEQ_REF}" "refs/tags/${LOGSEQ_REF}^{}" "refs/tags/${LOGSEQ_REF}" "$LOGSEQ_REF"; do
+              rev="$(git ls-remote "$remote" "$pattern" | head -1 | cut -f1)"
+              if [ -n "$rev" ]; then break; fi
+            done
+          fi
+          if [[ ! "$rev" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Could not resolve '${LOGSEQ_REF}' on ${LOGSEQ_REPO}" >&2
+            exit 1
+          fi
           echo "rev=${rev}" >>"$GITHUB_OUTPUT"
+          echo "repo=${LOGSEQ_REPO}" >>"$GITHUB_OUTPUT"
 
   build:
     needs: resolve-revision
@@ -56,18 +106,25 @@ jobs:
             arch: arm64
             runner: macos-26
             nix_system: aarch64-darwin
+        exclude:
+          - nix_system: ${{ !inputs.build_x86_64_linux && 'x86_64-linux' || '' }}
+          - nix_system: ${{ !inputs.build_aarch64_linux && 'aarch64-linux' || '' }}
+          - nix_system: ${{ !inputs.build_aarch64_darwin && 'aarch64-darwin' || '' }}
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Clone Logseq source
         env:
+          LOGSEQ_REPO: ${{ needs.resolve-revision.outputs.repo }}
           LOGSEQ_REV: ${{ needs.resolve-revision.outputs.rev }}
         run: |
           set -euo pipefail
           git init -q logseq-src
           cd logseq-src
-          git remote add origin https://github.com/logseq/logseq.git
+          git remote add origin "https://github.com/${LOGSEQ_REPO}.git"
           git fetch -q --depth 1 origin "${LOGSEQ_REV}"
           git checkout -q FETCH_HEAD
 
@@ -86,10 +143,6 @@ jobs:
             applied=$((applied + 1))
           done
           echo "Applied ${applied} upstream patch(es)"
-
-      - name: Set nightly metadata
-        id: metadata
-        run: echo "date=$(date -u +%Y%m%d)" >> "$GITHUB_OUTPUT"
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -193,11 +246,6 @@ jobs:
           patched = "".join(patched_lines)
           path.write_text(patched)
           PY
-        working-directory: logseq-src
-
-      - name: Record source revision
-        id: revision
-        run: echo "rev=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
         working-directory: logseq-src
 
       - name: Compile Logseq assets
@@ -345,29 +393,69 @@ jobs:
           hash=$(nix hash path --type sha256 --sri "$src_dir")
           printf '%s\n' "$hash" >"$hash_file"
 
-      - name: Write build metadata
-        if: matrix.arch == 'x64'
-        working-directory: logseq-src/static
-        run: |
-          set -euo pipefail
-          {
-            echo "version=${{ steps.version.outputs.value }}"
-            echo "revision=${{ steps.revision.outputs.rev }}"
-            echo "datestring=${{ steps.metadata.outputs.date }}"
-          } >out/meta.txt
-
-      - name: Render release notes
-        if: matrix.arch == 'x64'
-        working-directory: logseq-src
-        env:
-          LOGSEQ_REV: ${{ steps.revision.outputs.rev }}
-          MANIFEST_PATH: ../data/logseq-nightly.json
-          OUTPUT_PATH: static/out/release-notes.md
-        run: bash ../scripts/render-nightly-release-notes.sh
-
       - name: Upload build artifacts
         uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.os }}-build-${{ matrix.arch }}
           path: logseq-src/static/out/*
+          if-no-files-found: error
+
+  # metadata is a separate job so deselecting any arch leg (including x64)
+  # cannot drop meta.txt or release-notes.md. Version and datestring are
+  # recomputed here, so they can skew from per-leg tarball filenames across a
+  # UTC midnight boundary; accepted because release URLs derive from actual
+  # tarball basenames.
+  metadata:
+    needs: resolve-revision
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Clone source at resolved revision
+        env:
+          LOGSEQ_REPO: ${{ needs.resolve-revision.outputs.repo }}
+          LOGSEQ_REV: ${{ needs.resolve-revision.outputs.rev }}
+        run: |
+          set -euo pipefail
+          git init -q logseq-src
+          cd logseq-src
+          git remote add origin "https://github.com/${LOGSEQ_REPO}.git"
+          git fetch -q --depth 1 origin "${LOGSEQ_REV}"
+          git checkout -q FETCH_HEAD
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Write build metadata
+        env:
+          LOGSEQ_REV: ${{ needs.resolve-revision.outputs.rev }}
+        run: |
+          set -euo pipefail
+          mkdir -p out
+          version="$(cd logseq-src && node ./scripts/get-pkg-version.js nightly)"
+          {
+            echo "version=${version}"
+            echo "revision=${LOGSEQ_REV}"
+            echo "datestring=$(date -u +%Y%m%d)"
+          } >out/meta.txt
+
+      - name: Render release notes
+        working-directory: logseq-src
+        env:
+          LOGSEQ_REV: ${{ needs.resolve-revision.outputs.rev }}
+          UPSTREAM_REPO_URL: https://github.com/${{ needs.resolve-revision.outputs.repo }}
+          MANIFEST_PATH: ${{ github.workspace }}/data/logseq-nightly.json
+          OUTPUT_PATH: ${{ github.workspace }}/out/release-notes.md
+        run: bash "${GITHUB_WORKSPACE}/scripts/render-nightly-release-notes.sh"
+
+      - name: Upload metadata artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: build-metadata
+          path: out/*
           if-no-files-found: error

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -466,7 +466,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p out
-          version="$(cd logseq-src && node ./scripts/get-pkg-version.js nightly)"
+          version="$(cd logseq-src && node ./scripts/get-pkg-version.js nightly | tr -d '\r\n')"
           {
             echo "version=${version}"
             echo "revision=${LOGSEQ_REV}"

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -37,6 +37,11 @@ on:
         required: false
         type: boolean
         default: true
+      apply_patches:
+        description: "Apply patches/logseq-*.patch to the cloned source (rev-pinned fixes for the nightly rev)"
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -133,6 +138,7 @@ jobs:
       # build when upstream drifts or lands the fix, which is the signal to
       # update or drop the patch file.
       - name: Apply upstream patches
+        if: ${{ inputs.apply_patches }}
         working-directory: logseq-src
         run: |
           set -euo pipefail

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -235,7 +235,11 @@ jobs:
 
       - name: Determine nightly version
         id: version
-        run: echo "value=$(node ./scripts/get-pkg-version.js nightly | tr -d '\r\n')" >>"$GITHUB_OUTPUT"
+        run: |
+          set -euo pipefail
+          value="$(node ./scripts/get-pkg-version.js nightly | tr -d '\r\n')"
+          [[ "$value" =~ ^[A-Za-z0-9._+-]+$ ]] || { echo "Invalid version characters: $value" >&2; exit 1; }
+          echo "value=${value}" >>"$GITHUB_OUTPUT"
         working-directory: logseq-src
 
       - name: Update Nightly APP Version
@@ -471,6 +475,7 @@ jobs:
           set -euo pipefail
           mkdir -p out
           version="$(cd logseq-src && node ./scripts/get-pkg-version.js nightly | tr -d '\r\n')"
+          [[ "$version" =~ ^[A-Za-z0-9._+-]+$ ]] || { echo "Invalid version characters: $version" >&2; exit 1; }
           {
             echo "version=${version}"
             echo "revision=${LOGSEQ_REV}"

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -360,15 +360,11 @@ jobs:
         env:
           SOURCE_REPO: ${{ needs.resolve-target.outputs.repo }}
           PR_NUMBER: ${{ needs.resolve-target.outputs.pr_number }}
-          PR_URL: ${{ needs.resolve-target.outputs.html_url }}
-          BUILD_RESULT: ${{ needs.build.result }}
-          PUBLISH_RESULT: ${{ needs.publish.result }}
           SEL_X64: ${{ inputs.build_x86_64_linux }}
           SEL_ARM: ${{ inputs.build_aarch64_linux }}
           SEL_DARWIN: ${{ inputs.build_aarch64_darwin }}
           ASSETS_JSON: ${{ needs.publish.outputs.assets_json }}
           RELEASE_URL: ${{ needs.publish.outputs.release_url }}
-          RELEASE_TAG: ${{ needs.publish.outputs.tag }}
           KEEP_RELEASE: ${{ inputs.keep_release }}
           VALIDATE_RAN: ${{ needs.publish.outputs.validate_ran }}
           VALIDATE_SKIP_REASON: ${{ needs.publish.outputs.validate_skip_reason }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -85,7 +85,12 @@ jobs:
               echo "logseq_repo must be OWNER/REPO, got: $IN_REPO" >&2
               exit 1
             fi
-            { echo "repo=${IN_REPO}"; echo "ref=${IN_REF}"; echo "pr_number="; echo "html_url="; } >>"$GITHUB_OUTPUT"
+            safe_ref="$(printf '%s' "$IN_REF" | tr -d '\r\n')"
+            if [ -z "$safe_ref" ]; then
+              echo "logseq_ref must not be empty" >&2
+              exit 1
+            fi
+            { echo "repo=${IN_REPO}"; echo "ref=${safe_ref}"; echo "pr_number="; echo "html_url="; } >>"$GITHUB_OUTPUT"
             exit 0
           fi
           re='^https://github\.com/([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)/pull/([0-9]+)$'

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -3,6 +3,7 @@ name: PR Build
 # Dispatchable test build of a Logseq PR or branch from ANY repo (upstream
 # logseq/logseq or a fork such as Bad3r/Logseq). Logseq analog of
 # Defelo/nixpkgs-review-gha. Builds run UNTRUSTED code and receive no secrets.
+# Builds run on pristine PR source; patches/ is nightly-rev-pinned and skipped.
 on:
   workflow_dispatch:
     inputs:
@@ -118,6 +119,8 @@ jobs:
       build_x86_64_linux: ${{ inputs.build_x86_64_linux }}
       build_aarch64_linux: ${{ inputs.build_aarch64_linux }}
       build_aarch64_darwin: ${{ inputs.build_aarch64_darwin }}
+      # pr-build tests the PR's pristine code; local patches are pinned to the nightly rev
+      apply_patches: false
 
   publish:
     needs:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,380 @@
+name: PR Build
+
+# Dispatchable test build of a Logseq PR or branch from ANY repo (upstream
+# logseq/logseq or a fork such as Bad3r/Logseq). Logseq analog of
+# Defelo/nixpkgs-review-gha. Builds run UNTRUSTED code and receive no secrets.
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR URL (https://github.com/OWNER/REPO/pull/N); overrides repo/ref"
+        required: false
+        type: string
+        default: ""
+      logseq_repo:
+        description: "Source repository (owner/repo) when pr is empty"
+        required: false
+        type: string
+        default: logseq/logseq
+      logseq_ref:
+        description: "Branch, tag, or SHA when pr is empty"
+        required: false
+        type: string
+        default: master
+      build_x86_64_linux:
+        description: "Build x86_64-linux"
+        type: boolean
+        default: true
+      build_aarch64_linux:
+        description: "Build aarch64-linux"
+        type: boolean
+        default: true
+      build_aarch64_darwin:
+        description: "Build aarch64-darwin"
+        type: boolean
+        default: true
+      push_to_cachix:
+        description: "Push validation builds to Cachix"
+        type: boolean
+        default: false
+      keep_release:
+        description: "Keep the prerelease and assets after the run"
+        type: boolean
+        default: true
+      post_comment:
+        description: "Comment results on the source PR (needs GH_TOKEN secret)"
+        type: boolean
+        default: true
+      validate:
+        description: "Flake validation (auto = all archs green and repo is logseq/logseq)"
+        type: choice
+        default: auto
+        options:
+          - auto
+          - skip
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-build-${{ inputs.pr || format('{0}@{1}', inputs.logseq_repo, inputs.logseq_ref) }}
+  cancel-in-progress: true
+
+jobs:
+  resolve-target:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      repo: ${{ steps.target.outputs.repo }}
+      ref: ${{ steps.target.outputs.ref }}
+      pr_number: ${{ steps.target.outputs.pr_number }}
+      html_url: ${{ steps.target.outputs.html_url }}
+    steps:
+      - name: Resolve build target
+        id: target
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ inputs.pr }}
+          IN_REPO: ${{ inputs.logseq_repo }}
+          IN_REF: ${{ inputs.logseq_ref }}
+        run: |
+          set -euo pipefail
+          if [ -z "$PR_URL" ]; then
+            if [[ ! "$IN_REPO" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+              echo "logseq_repo must be OWNER/REPO, got: $IN_REPO" >&2
+              exit 1
+            fi
+            { echo "repo=${IN_REPO}"; echo "ref=${IN_REF}"; echo "pr_number="; echo "html_url="; } >>"$GITHUB_OUTPUT"
+            exit 0
+          fi
+          re='^https://github\.com/([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)/pull/([0-9]+)$'
+          if [[ ! "$PR_URL" =~ $re ]]; then
+            echo "Malformed PR URL: $PR_URL (expected https://github.com/OWNER/REPO/pull/N)" >&2
+            exit 1
+          fi
+          owner="${BASH_REMATCH[1]}"; repo="${BASH_REMATCH[2]}"; number="${BASH_REMATCH[3]}"
+          # Capture first: a failed API call (404, rate limit) must abort loudly.
+          pr_json="$(gh api "repos/${owner}/${repo}/pulls/${number}")"
+          state="$(jq -r '.state' <<<"$pr_json")"
+          head_sha="$(jq -r '.head.sha' <<<"$pr_json")"
+          [ "$state" = "open" ] || echo "::warning::PR #${number} state is '${state}'; building its head anyway."
+          [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]] || { echo "No head SHA for ${owner}/${repo}#${number}" >&2; exit 1; }
+          # Strip CR/LF to prevent GITHUB_OUTPUT newline injection.
+          html_url="$(jq -r '.html_url' <<<"$pr_json" | tr -d '\r\n')"
+          {
+            echo "repo=${owner}/${repo}"
+            # refs/pull/N/head is served by the BASE repo even for fork-head PRs.
+            echo "ref=refs/pull/${number}/head"
+            echo "pr_number=${number}"
+            echo "html_url=${html_url}"
+          } >>"$GITHUB_OUTPUT"
+
+  build:
+    needs: resolve-target
+    uses: ./.github/workflows/build-desktop.yml
+    with:
+      logseq_repo: ${{ needs.resolve-target.outputs.repo }}
+      logseq_ref: ${{ needs.resolve-target.outputs.ref }}
+      build_x86_64_linux: ${{ inputs.build_x86_64_linux }}
+      build_aarch64_linux: ${{ inputs.build_aarch64_linux }}
+      build_aarch64_darwin: ${{ inputs.build_aarch64_darwin }}
+
+  publish:
+    needs:
+      - resolve-target
+      - build
+    if: ${{ !cancelled() && needs.resolve-target.result == 'success' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    permissions:
+      contents: write
+      actions: read
+    outputs:
+      tag: ${{ steps.metadata.outputs.tag }}
+      release_url: ${{ steps.release.outputs.release-url }}
+      selected_systems: ${{ steps.present.outputs.selected }}
+      present_systems: ${{ steps.present.outputs.present }}
+      assets_json: ${{ steps.metadata.outputs.assets-json }}
+      version: ${{ steps.metadata.outputs.version }}
+      revision: ${{ steps.metadata.outputs.revision }}
+      validate_ran: ${{ steps.gate.outputs.run }}
+      validate_skip_reason: ${{ steps.gate.outputs.skip_reason }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Download packaged builds
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh run download "${{ github.run_id }}" --repo "${{ github.repository }}" --dir builds
+
+      - name: Compute present systems
+        id: present
+        env:
+          SEL_X64: ${{ inputs.build_x86_64_linux }}
+          SEL_ARM: ${{ inputs.build_aarch64_linux }}
+          SEL_DARWIN: ${{ inputs.build_aarch64_darwin }}
+        run: |
+          set -euo pipefail
+          present=""
+          selected=""
+          probe() {
+            local system="$1" sel="$2" glob="$3"
+            if [ "$sel" != "true" ]; then return 0; fi
+            selected="${selected}${system},"
+            if [ -n "$(find builds -name "$glob" -print -quit)" ]; then
+              present="${present}${system},"
+            else
+              echo "::warning::${system} selected but no artifact found (leg failed?)"
+            fi
+          }
+          probe x86_64-linux "$SEL_X64" 'logseq-linux-x64-*.tar.gz'
+          probe aarch64-linux "$SEL_ARM" 'logseq-linux-arm64-*.tar.gz'
+          probe aarch64-darwin "$SEL_DARWIN" 'logseq-darwin-arm64-*.tar.gz'
+          # Emit outputs before the exit-1 check so the comment job can read
+          # selected/present even when all legs failed.
+          echo "selected=${selected%,}" >>"$GITHUB_OUTPUT"
+          echo "present=${present%,}" >>"$GITHUB_OUTPUT"
+          if [ -z "$present" ]; then
+            echo "No build artifacts produced for any selected system" >&2
+            exit 1
+          fi
+
+      - name: Resolve build metadata
+        id: metadata
+        uses: ./.github/actions/resolve-build-metadata
+        with:
+          systems: ${{ steps.present.outputs.present }}
+          repo: ${{ github.repository }}
+          tag-prefix: ${{ needs.resolve-target.outputs.pr_number != '' && format('test-pr{0}-', needs.resolve-target.outputs.pr_number) || 'test-' }}
+          tag-suffix: -${{ github.run_id }}
+
+      - name: Compute release title
+        env:
+          PR_NUMBER: ${{ needs.resolve-target.outputs.pr_number }}
+          SOURCE_REPO: ${{ needs.resolve-target.outputs.repo }}
+          SOURCE_REF: ${{ needs.resolve-target.outputs.ref }}
+        run: |
+          set -euo pipefail
+          rev7="${BUILD_REVISION:0:7}"
+          if [ -n "$PR_NUMBER" ]; then
+            title="test build ${SOURCE_REPO}#${PR_NUMBER} (${rev7})"
+          else
+            title="test build ${SOURCE_REPO}@${SOURCE_REF} (${rev7})"
+          fi
+          echo "RELEASE_TITLE=${title}" >>"$GITHUB_ENV"
+
+      - name: Assemble asset list
+        id: assetlist
+        run: |
+          set -euo pipefail
+          {
+            echo 'assets<<EOF'
+            [ -n "${X64_TARBALL:-}" ] && echo "$X64_TARBALL"
+            [ -n "${ARM64_TARBALL:-}" ] && echo "$ARM64_TARBALL"
+            [ -n "${DARWIN_ARM64_TARBALL:-}" ] && echo "$DARWIN_ARM64_TARBALL"
+            echo 'EOF'
+          } >>"$GITHUB_OUTPUT"
+
+      - name: Publish test prerelease
+        id: release
+        uses: ./.github/actions/publish-release-assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag: ${{ env.RELEASE_TAG }}
+          title: ${{ env.RELEASE_TITLE }}
+          notes-file: ${{ env.RELEASE_NOTES }}
+          target: ${{ github.sha }}
+          prerelease: "true"
+          mark-latest: "false"
+          cleanup-tag: "true"
+          assets: ${{ steps.assetlist.outputs.assets }}
+
+      - name: Evaluate validation gate
+        id: gate
+        env:
+          VALIDATE_INPUT: ${{ inputs.validate }}
+          BUILD_RESULT: ${{ needs.build.result }}
+          SEL_X64: ${{ inputs.build_x86_64_linux }}
+          SEL_ARM: ${{ inputs.build_aarch64_linux }}
+          SEL_DARWIN: ${{ inputs.build_aarch64_darwin }}
+          SOURCE_REPO: ${{ needs.resolve-target.outputs.repo }}
+        run: |
+          set -euo pipefail
+          run=false
+          skip_reason=""
+          if [ "$VALIDATE_INPUT" = "skip" ]; then
+            skip_reason="validate=skip"
+          elif [ "$BUILD_RESULT" != "success" ]; then
+            skip_reason="build result is ${BUILD_RESULT}"
+          elif [ "$SEL_X64" != "true" ] || [ "$SEL_ARM" != "true" ] || [ "$SEL_DARWIN" != "true" ]; then
+            skip_reason="not all arch legs selected"
+          elif [ "$SOURCE_REPO" != "logseq/logseq" ]; then
+            skip_reason="source repo is ${SOURCE_REPO}, not logseq/logseq"
+          else
+            run=true
+          fi
+          if [ "$run" = "true" ]; then
+            echo "Validation will run."
+          else
+            echo "Skipping validation: ${skip_reason}"
+          fi
+          echo "run=${run}" >>"$GITHUB_OUTPUT"
+          echo "skip_reason=${skip_reason}" >>"$GITHUB_OUTPUT"
+
+      - name: Install Nix
+        if: steps.gate.outputs.run == 'true'
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            accept-flake-config = true
+
+      - name: Setup Cachix
+        if: steps.gate.outputs.run == 'true'
+        uses: cachix/cachix-action@v17
+        with:
+          name: nix-logseq-git-flake
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          skipPush: ${{ !inputs.push_to_cachix }}
+
+      - name: Regenerate manifest and CLI hashes
+        if: steps.gate.outputs.run == 'true'
+        run: bash scripts/update-nightly.sh
+
+      - name: Format repository
+        if: steps.gate.outputs.run == 'true'
+        run: nix fmt
+
+      - name: Validate flake against test release
+        if: steps.gate.outputs.run == 'true'
+        run: nix flake check --accept-flake-config
+
+      - name: Seed CLI fixed-output derivations to Cachix
+        if: ${{ steps.gate.outputs.run == 'true' && inputs.push_to_cachix }}
+        run: |
+          nix build --accept-flake-config --print-build-logs \
+            .#logseq-cli.cliCljDeps \
+            .#logseq-cli.cliPnpmDeps
+
+      - name: Capture regenerated manifest
+        if: steps.gate.outputs.run == 'true'
+        run: |
+          set -euo pipefail
+          mkdir -p pr-build-out
+          cp data/logseq-nightly.json pr-build-out/logseq-nightly.json
+          git --no-pager diff -- data/logseq-nightly.json >pr-build-out/logseq-nightly.json.diff || true
+
+      - name: Upload regenerated manifest
+        if: steps.gate.outputs.run == 'true'
+        uses: actions/upload-artifact@v6
+        with:
+          name: pr-build-manifest
+          path: pr-build-out/*
+          if-no-files-found: error
+
+      - name: Delete prerelease if keep_release is false
+        if: ${{ always() && !inputs.keep_release }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -n "${RELEASE_TAG:-}" ]; then
+            gh release delete "$RELEASE_TAG" --cleanup-tag -y || true
+          fi
+
+  comment:
+    needs:
+      - resolve-target
+      - build
+      - publish
+    if: ${{ !cancelled() && inputs.post_comment && needs.resolve-target.outputs.pr_number != '' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Verify GH_TOKEN is set
+        env:
+          COMMENT_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          [ -n "${COMMENT_TOKEN}" ] || {
+            echo "post_comment=true but secrets.GH_TOKEN (classic PAT, public_repo scope) is unset" >&2
+            exit 1
+          }
+
+      - name: Render PR comment report
+        env:
+          SOURCE_REPO: ${{ needs.resolve-target.outputs.repo }}
+          PR_NUMBER: ${{ needs.resolve-target.outputs.pr_number }}
+          PR_URL: ${{ needs.resolve-target.outputs.html_url }}
+          BUILD_RESULT: ${{ needs.build.result }}
+          PUBLISH_RESULT: ${{ needs.publish.result }}
+          SEL_X64: ${{ inputs.build_x86_64_linux }}
+          SEL_ARM: ${{ inputs.build_aarch64_linux }}
+          SEL_DARWIN: ${{ inputs.build_aarch64_darwin }}
+          ASSETS_JSON: ${{ needs.publish.outputs.assets_json }}
+          RELEASE_URL: ${{ needs.publish.outputs.release_url }}
+          RELEASE_TAG: ${{ needs.publish.outputs.tag }}
+          KEEP_RELEASE: ${{ inputs.keep_release }}
+          VALIDATE_RAN: ${{ needs.publish.outputs.validate_ran }}
+          VALIDATE_SKIP_REASON: ${{ needs.publish.outputs.validate_skip_reason }}
+          VERSION: ${{ needs.publish.outputs.version }}
+          REVISION: ${{ needs.publish.outputs.revision }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          OUTPUT_PATH: report.md
+        run: bash scripts/render-pr-build-report.sh
+
+      - name: Post comment on source PR
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          SOURCE_REPO: ${{ needs.resolve-target.outputs.repo }}
+          PR_NUMBER: ${{ needs.resolve-target.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          gh pr comment "$PR_NUMBER" -R "$SOURCE_REPO" -F report.md

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -182,9 +182,7 @@ jobs:
         uses: ./.github/actions/resolve-build-metadata
         with:
           systems: ${{ steps.present.outputs.present }}
-          repo: ${{ github.repository }}
           tag-prefix: ${{ needs.resolve-target.outputs.pr_number != '' && format('test-pr{0}-', needs.resolve-target.outputs.pr_number) || 'test-' }}
-          tag-suffix: -${{ github.run_id }}
 
       - name: Compute release title
         env:
@@ -201,32 +199,15 @@ jobs:
           fi
           echo "RELEASE_TITLE=${title}" >>"$GITHUB_ENV"
 
-      - name: Assemble asset list
-        id: assetlist
-        run: |
-          set -euo pipefail
-          {
-            echo 'assets<<EOF'
-            [ -n "${X64_TARBALL:-}" ] && echo "$X64_TARBALL"
-            [ -n "${ARM64_TARBALL:-}" ] && echo "$ARM64_TARBALL"
-            [ -n "${DARWIN_ARM64_TARBALL:-}" ] && echo "$DARWIN_ARM64_TARBALL"
-            echo 'EOF'
-          } >>"$GITHUB_OUTPUT"
-
+      # Tag, notes, and the present-arch asset list come from the RELEASE_*
+      # env handoff exported by resolve-build-metadata.
       - name: Publish test prerelease
         id: release
         uses: ./.github/actions/publish-release-assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag: ${{ env.RELEASE_TAG }}
           title: ${{ env.RELEASE_TITLE }}
-          notes-file: ${{ env.RELEASE_NOTES }}
-          target: ${{ github.sha }}
-          prerelease: "true"
-          mark-latest: "false"
-          cleanup-tag: "true"
-          assets: ${{ steps.assetlist.outputs.assets }}
 
       - name: Evaluate validation gate
         id: gate

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -69,7 +69,6 @@ jobs:
       repo: ${{ steps.target.outputs.repo }}
       ref: ${{ steps.target.outputs.ref }}
       pr_number: ${{ steps.target.outputs.pr_number }}
-      html_url: ${{ steps.target.outputs.html_url }}
     steps:
       - name: Resolve build target
         id: target
@@ -90,7 +89,7 @@ jobs:
               echo "logseq_ref must not be empty" >&2
               exit 1
             fi
-            { echo "repo=${IN_REPO}"; echo "ref=${safe_ref}"; echo "pr_number="; echo "html_url="; } >>"$GITHUB_OUTPUT"
+            { echo "repo=${IN_REPO}"; echo "ref=${safe_ref}"; echo "pr_number="; } >>"$GITHUB_OUTPUT"
             exit 0
           fi
           re='^https://github\.com/([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)/pull/([0-9]+)$'
@@ -105,14 +104,11 @@ jobs:
           head_sha="$(jq -r '.head.sha' <<<"$pr_json")"
           [ "$state" = "open" ] || echo "::warning::PR #${number} state is '${state}'; building its head anyway."
           [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]] || { echo "No head SHA for ${owner}/${repo}#${number}" >&2; exit 1; }
-          # Strip CR/LF to prevent GITHUB_OUTPUT newline injection.
-          html_url="$(jq -r '.html_url' <<<"$pr_json" | tr -d '\r\n')"
           {
             echo "repo=${owner}/${repo}"
             # refs/pull/N/head is served by the BASE repo even for fork-head PRs.
             echo "ref=refs/pull/${number}/head"
             echo "pr_number=${number}"
-            echo "html_url=${html_url}"
           } >>"$GITHUB_OUTPUT"
 
   build:
@@ -138,10 +134,7 @@ jobs:
       contents: write
       actions: read
     outputs:
-      tag: ${{ steps.metadata.outputs.tag }}
       release_url: ${{ steps.release.outputs.release-url }}
-      selected_systems: ${{ steps.present.outputs.selected }}
-      present_systems: ${{ steps.present.outputs.present }}
       assets_json: ${{ steps.metadata.outputs.assets-json }}
       version: ${{ steps.metadata.outputs.version }}
       revision: ${{ steps.metadata.outputs.revision }}
@@ -166,11 +159,9 @@ jobs:
         run: |
           set -euo pipefail
           present=""
-          selected=""
           probe() {
             local system="$1" sel="$2" glob="$3"
             if [ "$sel" != "true" ]; then return 0; fi
-            selected="${selected}${system},"
             if [ -n "$(find builds -name "$glob" -print -quit)" ]; then
               present="${present}${system},"
             else
@@ -180,14 +171,11 @@ jobs:
           probe x86_64-linux "$SEL_X64" 'logseq-linux-x64-*.tar.gz'
           probe aarch64-linux "$SEL_ARM" 'logseq-linux-arm64-*.tar.gz'
           probe aarch64-darwin "$SEL_DARWIN" 'logseq-darwin-arm64-*.tar.gz'
-          # Emit outputs before the exit-1 check so the comment job can read
-          # selected/present even when all legs failed.
-          echo "selected=${selected%,}" >>"$GITHUB_OUTPUT"
-          echo "present=${present%,}" >>"$GITHUB_OUTPUT"
           if [ -z "$present" ]; then
             echo "No build artifacts produced for any selected system" >&2
             exit 1
           fi
+          echo "present=${present%,}" >>"$GITHUB_OUTPUT"
 
       - name: Resolve build metadata
         id: metadata

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -110,7 +110,7 @@ jobs:
     needs: test-build-approval
     uses: ./.github/workflows/build-desktop.yml
     with:
-      logseq_branch: ${{ github.event.inputs.logseq_branch || 'master' }}
+      logseq_ref: ${{ github.event.inputs.logseq_branch || 'master' }}
 
   publish-test:
     runs-on: ubuntu-24.04
@@ -126,45 +126,17 @@ jobs:
         run: gh run download "${{ github.run_id }}" --repo "${{ github.repository }}" --dir builds
 
       - name: Resolve build metadata (isolated test tag)
-        env:
-          REPO: ${{ github.repository }}
-          RUN_ID: ${{ github.run_id }}
+        uses: ./.github/actions/resolve-build-metadata
+        with:
+          systems: x86_64-linux,aarch64-linux,aarch64-darwin
+          repo: ${{ github.repository }}
+          tag-prefix: test-
+          tag-suffix: -${{ github.run_id }}
+
+      - name: Compute release title
         run: |
           set -euo pipefail
-          meta="$(find builds -name meta.txt | head -1)"
-          x64_tar="$(find builds -name 'logseq-linux-x64-*.tar.gz' | head -1)"
-          arm64_tar="$(find builds -name 'logseq-linux-arm64-*.tar.gz' | head -1)"
-          darwin_arm64_tar="$(find builds -name 'logseq-darwin-arm64-*.tar.gz' | head -1)"
-          notes="$(find builds -name release-notes.md | head -1)"
-          x64_hash_file="$(find builds -name 'hash-x64.txt' | head -1)"
-          arm64_hash_file="$(find builds -name 'hash-arm64.txt' | head -1)"
-          darwin_arm64_hash_file="$(find builds -name 'hash-darwin-arm64.txt' | head -1)"
-          for f in "$meta" "$x64_tar" "$arm64_tar" "$darwin_arm64_tar" "$notes" "$x64_hash_file" "$arm64_hash_file" "$darwin_arm64_hash_file"; do
-            test -n "$f" || { echo "Required artifact file missing" >&2; exit 1; }
-          done
-          # meta.txt holds trusted build-step outputs (version/revision/datestring).
-          version="$(grep -E '^version=' "$meta" | cut -d= -f2-)"
-          revision="$(grep -E '^revision=' "$meta" | cut -d= -f2-)"
-          datestring="$(grep -E '^datestring=' "$meta" | cut -d= -f2-)"
-          # Disjoint tag namespace, unique per run: never collides with nightly-<date>.
-          tag="test-${datestring}-${RUN_ID}"
-          {
-            echo "LOGSEQ_VERSION=${version}"
-            echo "LOGSEQ_REV=${revision}"
-            echo "NIGHTLY_TAG=${tag}"
-            echo "RELEASE_TAG=${tag}"
-            echo "BUILD_REVISION=${revision}"
-            echo "X64_TARBALL=${x64_tar}"
-            echo "ARM64_TARBALL=${arm64_tar}"
-            echo "DARWIN_ARM64_TARBALL=${darwin_arm64_tar}"
-            echo "RELEASE_NOTES=${notes}"
-            echo "ASSET_URL_X86_64=https://github.com/${REPO}/releases/download/${tag}/$(basename "$x64_tar")"
-            echo "ASSET_SHA256_X86_64=$(cat "$x64_hash_file")"
-            echo "ASSET_URL_AARCH64=https://github.com/${REPO}/releases/download/${tag}/$(basename "$arm64_tar")"
-            echo "ASSET_SHA256_AARCH64=$(cat "$arm64_hash_file")"
-            echo "ASSET_URL_AARCH64_DARWIN=https://github.com/${REPO}/releases/download/${tag}/$(basename "$darwin_arm64_tar")"
-            echo "ASSET_SHA256_AARCH64_DARWIN=$(cat "$darwin_arm64_hash_file")"
-          } >>"$GITHUB_ENV"
+          echo "RELEASE_TITLE=test-build-${BUILD_REVISION:0:7}" >>"$GITHUB_ENV"
 
       - name: Install Nix
         uses: cachix/install-nix-action@v31
@@ -180,21 +152,21 @@ jobs:
           skipPush: true
 
       - name: Publish isolated test prerelease
+        uses: ./.github/actions/publish-release-assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HEAD_SHA: ${{ github.sha }}
-        run: |
-          set -euo pipefail
-          rev_short="${BUILD_REVISION:0:7}"
-          release_assets=("$X64_TARBALL" "$ARM64_TARBALL" "$DARWIN_ARM64_TARBALL")
-          # Idempotent on a same-run retry; the tag is deleted in cleanup regardless.
-          gh release delete "$RELEASE_TAG" --cleanup-tag -y || true
-          gh release create "$RELEASE_TAG" "${release_assets[@]}" \
-            --title "test-build-${rev_short}" \
-            --notes-file "$RELEASE_NOTES" \
-            --prerelease \
-            --latest=false \
-            --target "$HEAD_SHA"
+        with:
+          tag: ${{ env.RELEASE_TAG }}
+          title: ${{ env.RELEASE_TITLE }}
+          notes-file: ${{ env.RELEASE_NOTES }}
+          target: ${{ github.sha }}
+          prerelease: "true"
+          mark-latest: "false"
+          cleanup-tag: "true"
+          assets: |
+            ${{ env.X64_TARBALL }}
+            ${{ env.ARM64_TARBALL }}
+            ${{ env.DARWIN_ARM64_TARBALL }}
 
       - name: Regenerate manifest and CLI hashes
         run: bash scripts/update-nightly.sh

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -125,18 +125,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh run download "${{ github.run_id }}" --repo "${{ github.repository }}" --dir builds
 
+      # Composite defaults cover the isolated test flow: all systems, this
+      # repo, tag test-<datestring>-<run_id>.
       - name: Resolve build metadata (isolated test tag)
         uses: ./.github/actions/resolve-build-metadata
-        with:
-          systems: x86_64-linux,aarch64-linux,aarch64-darwin
-          repo: ${{ github.repository }}
-          tag-prefix: test-
-          tag-suffix: -${{ github.run_id }}
-
-      - name: Compute release title
-        run: |
-          set -euo pipefail
-          echo "RELEASE_TITLE=test-build-${BUILD_REVISION:0:7}" >>"$GITHUB_ENV"
 
       - name: Install Nix
         uses: cachix/install-nix-action@v31
@@ -151,22 +143,13 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           skipPush: true
 
+      # Tag, notes, and assets come from the RELEASE_* env handoff exported
+      # by resolve-build-metadata; the other defaults already fit a
+      # disposable test prerelease.
       - name: Publish isolated test prerelease
         uses: ./.github/actions/publish-release-assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag: ${{ env.RELEASE_TAG }}
-          title: ${{ env.RELEASE_TITLE }}
-          notes-file: ${{ env.RELEASE_NOTES }}
-          target: ${{ github.sha }}
-          prerelease: "true"
-          mark-latest: "false"
-          cleanup-tag: "true"
-          assets: |
-            ${{ env.X64_TARBALL }}
-            ${{ env.ARM64_TARBALL }}
-            ${{ env.DARWIN_ARM64_TARBALL }}
 
       - name: Regenerate manifest and CLI hashes
         run: bash scripts/update-nightly.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,10 @@ This file provides guidance to coding agents when working with this repository.
 - `modules/_packages/logseq-cli/` builds the upstream CLI from the Logseq monorepo as a shadow-cljs `:node-script` release, with offline pnpm deps and an offline Clojure dependency tree (Maven jars plus tools.gitlibs git checkouts).
 - `scripts/update-nightly.sh` regenerates manifest fields, CLI source/dependency hashes, and the CLI Clojure-deps hash.
 - `scripts/render-nightly-release-notes.sh` renders release notes from the cloned upstream Logseq repo.
+- `scripts/render-pr-build-report.sh` renders the per-arch result table posted as a PR comment by `pr-build.yml`.
 - `patches/` carries temporary fixes for upstream Logseq source; each patch header documents the bug and its removal condition.
+- `.github/actions/resolve-build-metadata/` is a composite action shared by `test-build.yml` and `pr-build.yml`: maps downloaded build artifacts to env vars and outputs (tarball paths, URLs, SRI hashes, tag).
+- `.github/actions/publish-release-assets/` is a composite action shared by `test-build.yml` and `pr-build.yml`: idempotently creates a GitHub release and attaches assets.
 - `.actrc` is tracked local `act` configuration; `.act/` is runtime state and stays ignored.
 - `.github/workflows/validate.yml` is the clearest snapshot of CI expectations.
 
@@ -38,7 +41,7 @@ The flake does **not** build Logseq Desktop from source inside Nix. It consumes 
 
 End-to-end data flow:
 
-1. `.github/workflows/nightly.yml` -> `build` job runs as a `strategy.matrix` over Linux x64 (`ubuntu-24.04`), Linux arm64 (`ubuntu-24.04-arm`), and Darwin arm64 (`macos-26`), **without** Nix during upstream compilation. Each leg clones upstream `logseq/logseq`, strict-applies `patches/logseq-*.patch`, installs upstream pnpm dependencies, runs `pnpm gulp:build && pnpm cljs:release-electron && pnpm db-worker-node:bundle && pnpm webpack-app-build && pnpm desktop:prepare-runtime-js` to populate `static/` and stage runtime JS under `static/js/`. Linux runs `pnpm electron:make` and packages `dist/linux*-unpacked` as `logseq-linux-<arch>-<version>.tar.gz`. Darwin verifies `rebuild:all` and `electron:make-macos-arm64`, runs `pnpm rebuild:all && pnpm electron:make-macos-arm64`, copies the single `dist/mac-arm64/*.app` into a clean top-level `Logseq.app` payload, ad-hoc signs it, then packages `logseq-darwin-arm64-<version>.tar.gz`. Each leg writes an SRI hash file; the x64 leg additionally writes shared `meta.txt` (version/revision/datestring) and rendered release notes, because matrix job `outputs` are unreliable.
+1. `.github/workflows/nightly.yml` delegates to the reusable `.github/workflows/build-desktop.yml`, which is parameterized by `logseq_repo`/`logseq_ref`, per-arch boolean toggles (`build_x86_64_linux`, `build_aarch64_linux`, `build_aarch64_darwin`), and `apply_patches` (default true; gates the strict patch step). The `build` matrix runs over Linux x64 (`ubuntu-24.04`), Linux arm64 (`ubuntu-24.04-arm`), and Darwin arm64 (`macos-26`), **without** Nix during upstream compilation. Each leg clones the upstream repo at the resolved revision, optionally strict-applies `patches/logseq-*.patch`, installs upstream pnpm dependencies, runs `pnpm gulp:build && pnpm cljs:release-electron && pnpm db-worker-node:bundle && pnpm webpack-app-build && pnpm desktop:prepare-runtime-js` to populate `static/` and stage runtime JS under `static/js/`. Linux runs `pnpm electron:make` and packages `dist/linux*-unpacked` as `logseq-linux-<arch>-<version>.tar.gz`. Darwin verifies `rebuild:all` and `electron:make-macos-arm64`, runs `pnpm rebuild:all && pnpm electron:make-macos-arm64`, copies the single `dist/mac-arm64/*.app` into a clean top-level `Logseq.app` payload, ad-hoc signs it, then packages `logseq-darwin-arm64-<version>.tar.gz`. Each leg writes an SRI hash file and its tarball as artifacts. A separate `metadata` job (parallel to the build matrix) clones the upstream repo, computes version/revision/datestring, renders release notes, and uploads a `build-metadata` artifact containing `meta.txt` and `release-notes.md`; this decouples metadata from any single arch leg so deselecting any leg (including x64) cannot drop shared metadata (matrix job `outputs` are unreliable).
 2. `.github/workflows/nightly.yml` -> `publish-release` job downloads build artifacts, resolves shared metadata + per-system hashes, requires Linux and Darwin tarballs plus their SRI hash files, installs Nix + Cachix, publishes all three tarballs, then runs `bash scripts/update-nightly.sh`. The Darwin matrix leg is release-blocking, so a Darwin build failure or missing Darwin artifact prevents publishing. `workflow_dispatch` can set `publish_release=false` to validate the build matrix without creating a release or committing a manifest bump.
 3. `scripts/update-nightly.sh` rewrites `data/logseq-nightly.json` with the per-system release URLs + SRI hashes (under `assets.<system>`), upstream rev, and CLI version. It requires `ASSET_URL_X86_64`, `ASSET_SHA256_X86_64`, `ASSET_URL_AARCH64`, `ASSET_SHA256_AARCH64`, `ASSET_URL_AARCH64_DARWIN`, and `ASSET_SHA256_AARCH64_DARWIN`. It resolves `cliPnpmDepsHash` and `cliCljDepsHash` with deliberate placeholder fixed-output builds, parsing the resulting `got: sha256-...` error from stderr and rewriting the manifest after each hash.
 4. `nix flake check` validates the updated manifest through `lib/loadManifest.nix`, rebuilds both packages, then the `logseq-nightly-bot` auto-commits the manifest bump to `main`.
@@ -73,6 +76,35 @@ When a nightly fails, first check whether upstream renamed a path, changed the p
 - `modules/_packages/logseq-cli/build.nix` lists only the patches that touch files compiled into the CLI in its `patches` attribute. Patching happens in the build derivation, not the source FOD, so `cliSrcHash`, `cliPnpmDepsHash`, and `cliCljDepsHash` stay unchanged.
 
 Rules: every patch header must explain the bug and name its removal condition. Strict apply is the drift guard; when a nightly or CLI build fails at patch application, upstream either landed the fix (delete the patch and its `build.nix` reference) or moved the code (regenerate the patch against the new tree). Keep the two apply sites in sync in the same change. Verify a new or regenerated patch with `git apply --check` against a checkout of `manifest.logseqRev` before committing.
+
+### PR test builds (pr-build.yml)
+
+`pr-build.yml` is a dispatch-only analog of nixpkgs-review-gha. It builds any PR URL
+(`https://github.com/OWNER/REPO/pull/N`) or an arbitrary repo+ref from upstream or forks,
+with per-arch boolean toggles.
+
+Key properties:
+
+- Builds run untrusted code. The reusable `build-desktop.yml` job receives no secrets;
+  `apply_patches: false` so the PR's pristine source is tested (patches/ is pinned to the
+  nightly rev and would not apply cleanly against arbitrary PR heads).
+- Publishes present-arch tarballs as a prerelease tagged `test-pr<N>-<date>-<runid>` (for PR
+  input) or `test-<date>-<runid>` (for branch/ref input) on this repo. `keep_release`
+  (default true) keeps the release for manual testing; manual cleanup is
+  `gh release delete <tag> --cleanup-tag`. A failed arch leg does not block publishing the
+  rest.
+- `validate=auto` (default) runs `scripts/update-nightly.sh` + `nix fmt` + `nix flake check`
+  ONLY when all three arch legs were selected AND built green AND the source repo is
+  `logseq/logseq`. `push_to_cachix` (default false) optionally pushes validation store paths
+  plus CLI FOD seeds.
+- `post_comment` (default true) posts a per-arch result table (download links, SRI hashes,
+  log links) on the source PR. This requires the repo secret `GH_TOKEN` (classic PAT,
+  `public_repo` scope), used exclusively by the `comment` job. `GITHUB_TOKEN` cannot comment
+  cross-repo. The `comment` job fails loudly when `post_comment=true` and the secret is unset.
+
+`test-build.yml`'s `publish-test` step uses the same two composites
+(`.github/actions/resolve-build-metadata` and `.github/actions/publish-release-assets`);
+the behavior of that step is otherwise identical to before the composites were introduced.
 
 ### Desktop packaging
 
@@ -174,7 +206,7 @@ Required env vars for `scripts/update-nightly.sh`: `LOGSEQ_REV`, `LOGSEQ_VERSION
 - `patches/**`: verify each changed patch with `git apply --check` against a checkout of `manifest.logseqRev`, then run `nix build .#logseq-cli` and `nix build .#checks.x86_64-linux.logseq-cli-login-callback` when the patch affects the CLI. Desktop-only patches get exercised by the next nightly (or a `test-build` run); there is no local desktop compile.
 - `lib/loadManifest.nix` or `data/logseq-nightly.json`: run `nix build .#checks.x86_64-linux.logseq-runtime-assets` for desktop ASAR layout changes, or `nix flake check` for broader manifest/load-path changes. For Darwin asset changes, use the `aarch64-darwin` runtime-assets check in CI once the Darwin hash is real.
 - `flake.lock`: if the bump changes `git` or `zlib`, the CLI Clojure-deps FOD output can change bytes (its git deps are exploded to loose objects, whose encoding depends on those tools), so `nix build .#logseq-cli` fails with a `cliCljDepsHash` mismatch until `scripts/update-nightly.sh` re-resolves the hash; the nightly workflow is the only flow that re-resolves it automatically. Validate lock bumps with `nix build .#checks.x86_64-linux.logseq-cli` (or the `logseq-cli-help` check) before merging.
-- `.github/workflows/*.yml` or `scripts/*.sh`: run the relevant formatter, then `nix develop -c pre-commit run --all-files` if practical. Use the long-running local `act` build only when the workflow or script change materially affects the nightly build path and smaller checks cannot cover it.
+- `.github/workflows/*.yml`, `.github/actions/**`, or `scripts/*.sh`: run the relevant formatter, then `nix develop -c pre-commit run --all-files` if practical. Use the long-running local `act` build only when the workflow, composite action, or script change materially affects the nightly build path and smaller checks cannot cover it.
 - Hook config changes: run `nix build .#checks.x86_64-linux.pre-commit-check`; for pre-push-only hooks, also run the specific hook with `nix develop -c pre-commit run <hook> --hook-stage pre-push --all-files`.
 
 ## Code Style Guidelines
@@ -223,6 +255,7 @@ Required env vars for `scripts/update-nightly.sh`: `LOGSEQ_REV`, `LOGSEQ_VERSION
 - Keep shell indentation compatible with `shfmt -i 2`.
 - Preserve the existing GitHub Actions style: explicit timeouts, concurrency groups, scoped permissions, and current major-pinned action versions.
 - PRs touching `.github/workflows/*` or `flake.lock` trigger a policy check that requires the `status(security-review-approved)` label.
+- `pr-build.yml` requires a repo secret `GH_TOKEN` (classic PAT, `public_repo` scope) to post PR comments cross-repo. The `comment` job skips automatically when `post_comment=false` or no PR number is resolved; it fails loudly when `post_comment=true` and the secret is absent. `GITHUB_TOKEN` cannot comment on PRs in external repos.
 
 ### JSON, Markdown, and YAML
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,8 @@ This file provides guidance to coding agents when working with this repository.
 - `scripts/render-nightly-release-notes.sh` renders release notes from the cloned upstream Logseq repo.
 - `scripts/render-pr-build-report.sh` renders the per-arch result table posted as a PR comment by `pr-build.yml`.
 - `patches/` carries temporary fixes for upstream Logseq source; each patch header documents the bug and its removal condition.
-- `.github/actions/resolve-build-metadata/` is a composite action shared by `test-build.yml` and `pr-build.yml`: maps downloaded build artifacts to env vars and outputs (tarball paths, URLs, SRI hashes, tag).
-- `.github/actions/publish-release-assets/` is a composite action shared by `test-build.yml` and `pr-build.yml`: idempotently creates a GitHub release and attaches assets.
+- `.github/actions/resolve-build-metadata/` is a composite action shared by `test-build.yml` and `pr-build.yml`: maps downloaded build artifacts to env vars and outputs (tarball paths, URLs, SRI hashes, tag). Input defaults cover the test flow (all systems, current repo, tag `test-<datestring>-<run_id>`); it exports `RELEASE_TAG`, `RELEASE_NOTES`, and `RELEASE_ASSETS` for the publish composite.
+- `.github/actions/publish-release-assets/` is a composite action shared by `test-build.yml` and `pr-build.yml`: idempotently creates a GitHub release and attaches assets. All inputs are optional; tag, notes, and assets fall back to the `RELEASE_*` env handoff from `resolve-build-metadata`, target defaults to the current commit, and `prerelease`/`cleanup-tag` default to true (a future nightly caller would override these). It fails loudly when no asset paths resolve.
 - `.actrc` is tracked local `act` configuration; `.act/` is runtime state and stays ignored.
 - `.github/workflows/validate.yml` is the clearest snapshot of CI expectations.
 
@@ -102,9 +102,11 @@ Key properties:
   `public_repo` scope), used exclusively by the `comment` job. `GITHUB_TOKEN` cannot comment
   cross-repo. The `comment` job fails loudly when `post_comment=true` and the secret is unset.
 
-`test-build.yml`'s `publish-test` step uses the same two composites
-(`.github/actions/resolve-build-metadata` and `.github/actions/publish-release-assets`);
-the behavior of that step is otherwise identical to before the composites were introduced.
+`test-build.yml`'s `publish-test` job calls the same two composites
+(`.github/actions/resolve-build-metadata` and `.github/actions/publish-release-assets`)
+with no inputs at all: the composite defaults plus the `RELEASE_*` env handoff produce
+the isolated `test-<datestring>-<run_id>` prerelease (title = tag). `pr-build.yml`
+overrides only `systems` (present arch legs), `tag-prefix` (PR number), and `title`.
 
 ### Desktop packaging
 

--- a/scripts/render-pr-build-report.sh
+++ b/scripts/render-pr-build-report.sh
@@ -91,7 +91,8 @@ render_row() {
   if [ -n "$REVISION" ]; then
     rev7="${REVISION:0:7}"
     version_str=""
-    [ -n "$VERSION" ] && version_str=" (version \`${VERSION}\`)"
+    safe_version="${VERSION//\`/}"
+    [ -n "$safe_version" ] && version_str=" (version \`${safe_version}\`)"
     # shellcheck disable=SC2016
     printf 'Built from [`%s`](https://github.com/%s/commit/%s)%s by [pr-build](%s)\n\n' \
       "$rev7" "$SOURCE_REPO" "$REVISION" "$version_str" "$RUN_URL"

--- a/scripts/render-pr-build-report.sh
+++ b/scripts/render-pr-build-report.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# render-pr-build-report.sh - Render a Markdown PR comment for a pr-build run.
+#
+# All inputs via environment variables. Requires jq on PATH (available on all
+# GitHub Actions runners; install locally with nix run nixpkgs#jq for testing).
+#
+# Required:
+#   SOURCE_REPO  - owner/repo of the PR source (e.g. logseq/logseq)
+#   PR_NUMBER    - PR number (e.g. 42)
+#   RUN_URL      - URL of the Actions run (for log links)
+#   OUTPUT_PATH  - file path to write the rendered report
+#
+# Optional (graceful degradation when absent or empty):
+#   PR_URL            - full PR HTML URL
+#   BUILD_RESULT      - GitHub job result string (success/failure/cancelled/skipped)
+#   PUBLISH_RESULT    - GitHub job result string for the publish job
+#   SEL_X64           - "true"/"false" whether x86_64-linux was selected
+#   SEL_ARM           - "true"/"false" whether aarch64-linux was selected
+#   SEL_DARWIN        - "true"/"false" whether aarch64-darwin was selected
+#   ASSETS_JSON       - compact JSON array from resolve-build-metadata outputs
+#   RELEASE_URL       - URL of the GitHub release
+#   RELEASE_TAG       - release tag name
+#   KEEP_RELEASE      - "true"/"false" whether assets are kept after the run
+#   VALIDATE_RAN      - "true"/"false" whether flake validation ran
+#   VALIDATE_SKIP_REASON - reason validation was skipped (when VALIDATE_RAN != true)
+#   VERSION           - Logseq version string
+#   REVISION          - upstream commit SHA (40 hex chars)
+
+set -euo pipefail
+
+: "${SOURCE_REPO:?SOURCE_REPO must be set}"
+: "${PR_NUMBER:?PR_NUMBER must be set}"
+: "${RUN_URL:?RUN_URL must be set}"
+: "${OUTPUT_PATH:?OUTPUT_PATH must be set}"
+
+SEL_X64="${SEL_X64:-false}"
+SEL_ARM="${SEL_ARM:-false}"
+SEL_DARWIN="${SEL_DARWIN:-false}"
+ASSETS_JSON="${ASSETS_JSON:-[]}"
+RELEASE_URL="${RELEASE_URL:-}"
+RELEASE_TAG="${RELEASE_TAG:-}"
+KEEP_RELEASE="${KEEP_RELEASE:-true}"
+VALIDATE_RAN="${VALIDATE_RAN:-false}"
+VALIDATE_SKIP_REASON="${VALIDATE_SKIP_REASON:-}"
+VERSION="${VERSION:-}"
+REVISION="${REVISION:-}"
+BUILD_RESULT="${BUILD_RESULT:-}"
+PUBLISH_RESULT="${PUBLISH_RESULT:-}"
+
+# --- Helpers ---
+
+# Look up a system in ASSETS_JSON; print the matching object or empty string.
+lookup_asset() {
+  local system="$1"
+  if [ "$ASSETS_JSON" = "[]" ] || [ -z "$ASSETS_JSON" ]; then
+    echo ""
+    return
+  fi
+  jq -c --arg s "$system" '.[] | select(.system == $s)' <<<"$ASSETS_JSON" 2>/dev/null || echo ""
+}
+
+# Render one table row. Arguments: system label, selected ("true"/"false").
+render_row() {
+  local system="$1" label="$2" sel="$3"
+  if [ "$sel" != "true" ]; then
+    printf '| %s | not selected | |\n' "$label"
+    return
+  fi
+  local asset
+  asset="$(lookup_asset "$system")"
+  if [ -n "$asset" ]; then
+    local url tarball hash tarball_name
+    url="$(jq -r '.url' <<<"$asset")"
+    tarball="$(jq -r '.tarball' <<<"$asset")"
+    hash="$(jq -r '.sha256' <<<"$asset")"
+    # tarball_name is trusted to match the upstream version-string shape
+    # (logseq-<os>-<arch>-<version>.tar.gz), so using it as Markdown link text is accepted by design.
+    tarball_name="$(basename "$tarball")"
+    # shellcheck disable=SC2016
+    printf '| %s | built | [%s](%s) `%s` |\n' "$label" "$tarball_name" "$url" "$hash"
+  else
+    printf '| %s | failed ([logs](%s)) | |\n' "$label" "$RUN_URL"
+  fi
+}
+
+# --- Header ---
+
+{
+  printf '## Logseq test build: %s#%s\n\n' "$SOURCE_REPO" "$PR_NUMBER"
+
+  if [ -n "$REVISION" ]; then
+    rev7="${REVISION:0:7}"
+    version_str=""
+    [ -n "$VERSION" ] && version_str=" (version \`${VERSION}\`)"
+    # shellcheck disable=SC2016
+    printf 'Built from [`%s`](https://github.com/%s/commit/%s)%s by [pr-build](%s)\n\n' \
+      "$rev7" "$SOURCE_REPO" "$REVISION" "$version_str" "$RUN_URL"
+  fi
+
+  # --- Per-system table ---
+
+  printf '| System | Result | Download |\n'
+  printf '| --- | --- | --- |\n'
+  render_row x86_64-linux x86_64-linux "$SEL_X64"
+  render_row aarch64-linux aarch64-linux "$SEL_ARM"
+  render_row aarch64-darwin aarch64-darwin "$SEL_DARWIN"
+  printf '\n'
+
+  # --- Flake validation ---
+
+  if [ "$VALIDATE_RAN" = "true" ]; then
+    printf 'Flake validation: ran\n\n'
+  else
+    reason="${VALIDATE_SKIP_REASON:-unknown reason}"
+    printf 'Flake validation: skipped (%s)\n\n' "$reason"
+  fi
+
+  # --- Release link ---
+
+  if [ -n "$RELEASE_URL" ]; then
+    if [ "$KEEP_RELEASE" = "true" ]; then
+      printf 'Release: %s (assets kept for testing)\n\n' "$RELEASE_URL"
+    else
+      printf 'Release: %s (deleted after this run)\n\n' "$RELEASE_URL"
+    fi
+  else
+    printf 'Release: not published\n\n'
+  fi
+
+  # --- Footer ---
+
+  printf '_This is an unsigned, unofficial test build of unreviewed PR code. Install at your own risk._\n'
+
+} >"$OUTPUT_PATH"

--- a/scripts/render-pr-build-report.sh
+++ b/scripts/render-pr-build-report.sh
@@ -66,9 +66,9 @@ render_row() {
     url="$(jq -r '.url' <<<"$asset")"
     tarball="$(jq -r '.tarball' <<<"$asset")"
     hash="$(jq -r '.sha256' <<<"$asset")"
-    # tarball_name is trusted to match the upstream version-string shape
-    # (logseq-<os>-<arch>-<version>.tar.gz), so using it as Markdown link text is accepted by design.
-    tarball_name="$(basename "$tarball")"
+    # PR-controlled version text can inject Markdown link or table syntax through the tarball basename.
+    tarball_name="$(basename "$tarball" | tr -cd 'A-Za-z0-9._-')"
+    [ -n "$tarball_name" ] || tarball_name="artifact"
     # shellcheck disable=SC2016
     printf '| %s | built | [%s](%s) `%s` |\n' "$label" "$tarball_name" "$url" "$hash"
   else

--- a/scripts/render-pr-build-report.sh
+++ b/scripts/render-pr-build-report.sh
@@ -11,15 +11,11 @@
 #   OUTPUT_PATH  - file path to write the rendered report
 #
 # Optional (graceful degradation when absent or empty):
-#   PR_URL            - full PR HTML URL
-#   BUILD_RESULT      - GitHub job result string (success/failure/cancelled/skipped)
-#   PUBLISH_RESULT    - GitHub job result string for the publish job
 #   SEL_X64           - "true"/"false" whether x86_64-linux was selected
 #   SEL_ARM           - "true"/"false" whether aarch64-linux was selected
 #   SEL_DARWIN        - "true"/"false" whether aarch64-darwin was selected
 #   ASSETS_JSON       - compact JSON array from resolve-build-metadata outputs
 #   RELEASE_URL       - URL of the GitHub release
-#   RELEASE_TAG       - release tag name
 #   KEEP_RELEASE      - "true"/"false" whether assets are kept after the run
 #   VALIDATE_RAN      - "true"/"false" whether flake validation ran
 #   VALIDATE_SKIP_REASON - reason validation was skipped (when VALIDATE_RAN != true)
@@ -38,14 +34,11 @@ SEL_ARM="${SEL_ARM:-false}"
 SEL_DARWIN="${SEL_DARWIN:-false}"
 ASSETS_JSON="${ASSETS_JSON:-[]}"
 RELEASE_URL="${RELEASE_URL:-}"
-RELEASE_TAG="${RELEASE_TAG:-}"
 KEEP_RELEASE="${KEEP_RELEASE:-true}"
 VALIDATE_RAN="${VALIDATE_RAN:-false}"
 VALIDATE_SKIP_REASON="${VALIDATE_SKIP_REASON:-}"
 VERSION="${VERSION:-}"
 REVISION="${REVISION:-}"
-BUILD_RESULT="${BUILD_RESULT:-}"
-PUBLISH_RESULT="${PUBLISH_RESULT:-}"
 
 # --- Helpers ---
 


### PR DESCRIPTION
## Summary

- Adds a dispatchable `pr-build.yml` workflow (Logseq analog of Defelo/nixpkgs-review-gha): test-builds any PR URL (`https://github.com/OWNER/REPO/pull/N`) or repo+ref from `logseq/logseq` or any fork, with per-arch toggles, and publishes the per-arch tarballs as a persistent prerelease (`test-pr<N>-<date>-<runid>`) others can download.
- Generalizes the reusable `build-desktop.yml`: `logseq_repo`/`logseq_ref` inputs (branch/tag/SHA/`refs/pull/N/head`), boolean per-arch matrix pruning, `apply_patches` toggle (default true; pr-build builds pristine PR source since `patches/` is pinned to the nightly rev), checkout hardening (`persist-credentials: false`), and a dedicated `metadata` job producing the `build-metadata` artifact so optional arch legs cannot drop `meta.txt`/`release-notes.md`.
- Extracts the duplicated publish shell into composite actions `resolve-build-metadata` (strict artifact-to-env mapping, preserves the `scripts/update-nightly.sh` env contract) and `publish-release-assets` (idempotent `gh release delete`/`create`); `test-build.yml` is refactored onto them with behavior verified identical (tag shape, flag set, title, env contract).
- Optional flake validation (`validate=auto`: runs `update-nightly.sh` + `nix fmt` + `nix flake check` only when all three archs are selected, built green, and the source repo is `logseq/logseq`), optional Cachix push, and an optional per-arch result comment (download links + SRI hashes + log links) posted on the source PR via `scripts/render-pr-build-report.sh`.
- `nightly.yml` is byte-untouched; its call site keeps current behavior through input defaults.

## Security posture

- The build matrix executes untrusted PR code with no secrets, a read-only token, and `persist-credentials: false`; `CACHIX_AUTH_TOKEN` exists only in `publish`; the `GH_TOKEN` PAT only in `comment`.
- User-influenced values (repo, ref, PR title/url) are regex-validated and reach shell only via env indirection; resolve-target outputs are CR/LF-stripped.

## Prerequisites before first real use

- Repo secret `GH_TOKEN` (classic PAT, `public_repo` scope) for the comment job; the job fails loudly when `post_comment=true` and the secret is missing.
- This PR touches `.github/workflows/*`, so it needs the `status(security-review-approved)` label for the policy check, which also lets the test-build gate exercise the modified build path end-to-end.

## Test Plan

- [x] `nix develop -c pre-commit run --all-files` green after every commit (treefmt, actionlint, shellcheck, statix, deadnix, dprint)
- [x] `act -l` parses `pr-build.yml` and `test-build.yml` job graphs
- [x] `scripts/render-pr-build-report.sh` exercised locally for all-built, partial, and none-built cases (plus empty REVISION/RELEASE_URL degradation)
- [x] Composite shell logic smoke-tested locally: strict missing/ambiguous artifact failures, env/output emission, gh argv reproduction for both nightly-style and test-style flag sets
- [x] `nix develop -c pre-commit run gitleaks --hook-stage manual` clean before push
- [ ] PR gate: test-build pipeline against an isolated prerelease (runs on this PR once labeled)
- [ ] Post-merge smoke: `gh workflow run pr-build.yml -f pr=<fork PR url> -f build_aarch64_linux=false -f build_aarch64_darwin=false -f post_comment=false`, then a full upstream run with `keep_release=false` to confirm validate-auto and cleanup
