### PR TITLE
fix(cli): bind login callbacks on both loopback families

### DIFF
--- a/modules/_checks/cli-login-callback.nix
+++ b/modules/_checks/cli-login-callback.nix
@@ -1,8 +1,9 @@
 { cli, pkgs }:
 # Regression check for the patches/logseq-cli-auth-bind-ipv4-loopback.patch
-# behavior: `logseq-cli login` must serve its OAuth callback on the IPv4
-# loopback literal. Upstream binds the resolver's first "localhost" address
-# (often ::1 only), which IPv4-only browsers cannot reach. The probe stays
+# behavior: `logseq-cli login` must serve its OAuth callback on both explicit
+# loopback address families when the host supports them. Upstream binds the
+# resolver's first "localhost" address only, so browser address-family policy
+# can choose a callback address that the CLI never bound. The probe stays
 # hermetic: the browser opener is stubbed to capture the authorize URL, and a
 # deliberate state mismatch makes the CLI reject the callback before any
 # token-exchange network traffic.
@@ -16,96 +17,138 @@ let
   '';
 in
 pkgs.runCommand "logseq-cli-login-callback-check" { } ''
-  export HOME=$TMPDIR
-  export XDG_CACHE_HOME=$TMPDIR/cache
+  set -euo pipefail
 
-  mkdir -p "$TMPDIR/bin"
-  ln -s ${openerStub} "$TMPDIR/bin/xdg-open"
-  ln -s ${openerStub} "$TMPDIR/bin/open"
-  export PATH="$TMPDIR/bin:$PATH"
+  extract_state() {
+    printf '%s' "$1" | ${pkgs.gnused}/bin/sed -n 's/^.*[?&]state=\([^&]*\).*$/\1/p' | ${pkgs.coreutils}/bin/tr -d '\r'
+  }
 
-  ${cli}/bin/logseq-cli login >"$TMPDIR/login-output" 2>&1 &
-  login_pid=$!
+  wait_for_authorize_url() {
+    dir="$1"
+    pid="$2"
+    tries=0
+    while [ ! -s "$dir/authorize-url" ]; do
+      tries=$((tries + 1))
+      if [ "$tries" -gt 120 ]; then
+        echo "logseq-cli login did not produce an authorize URL within 120s" >&2
+        cat "$dir/login-output" >&2
+        return 1
+      fi
+      if ! kill -0 "$pid" 2>/dev/null; then
+        echo "logseq-cli login exited before opening the browser:" >&2
+        cat "$dir/login-output" >&2
+        return 1
+      fi
+      sleep 1
+    done
+  }
 
-  # The authorize URL is written only after the callback server's listen
-  # callback resolved, so its presence means the server is accepting
-  # connections.
-  tries=0
-  while [ ! -s "$TMPDIR/authorize-url" ]; do
-    tries=$((tries + 1))
-    if [ "$tries" -gt 120 ]; then
-      echo "logseq-cli login did not produce an authorize URL within 120s" >&2
-      cat "$TMPDIR/login-output" >&2
-      kill "$login_pid" 2>/dev/null || true
+  probe_family() {
+    family="$1"
+    callback_base="$2"
+    dir="$TMPDIR/$family"
+    login_pid=""
+    trap 'if [ -n "$login_pid" ]; then kill "$login_pid" 2>/dev/null || true; wait "$login_pid" 2>/dev/null || true; login_pid=""; fi' EXIT
+
+    mkdir -p "$dir/bin" "$dir/home" "$dir/cache"
+    ln -s ${openerStub} "$dir/bin/xdg-open"
+    ln -s ${openerStub} "$dir/bin/open"
+
+    HOME="$dir/home" \
+      TMPDIR="$dir" \
+      XDG_CACHE_HOME="$dir/cache" \
+      PATH="$dir/bin:$PATH" \
+      ${cli}/bin/logseq-cli login >"$dir/login-output" 2>&1 &
+    login_pid=$!
+
+    # The authorize URL is written only after the callback server's listen
+    # callback resolved, so its presence means the server is accepting
+    # connections.
+    wait_for_authorize_url "$dir" "$login_pid"
+
+    authorize_url="$(cat "$dir/authorize-url")"
+    state="$(extract_state "$authorize_url")"
+    if [ -z "$state" ]; then
+      echo "$family: authorize URL is missing the OAuth state parameter:" >&2
+      printf '%s\n' "$authorize_url" >&2
       exit 1
     fi
-    if ! kill -0 "$login_pid" 2>/dev/null; then
-      echo "logseq-cli login exited before opening the browser:" >&2
-      cat "$TMPDIR/login-output" >&2
+
+    http_status=0
+    if ! http_status="$(${pkgs.curl}/bin/curl --silent --show-error --noproxy '*' --max-time 10 \
+      --output "$dir/callback-body" --write-out '%{http_code}' \
+      "$callback_base?code=probe&state=mismatch-$state")"; then
+      echo "$family: callback probe could not connect to $callback_base" >&2
+      cat "$dir/login-output" >&2
       exit 1
     fi
-    sleep 1
-  done
 
-  authorize_url="$(cat "$TMPDIR/authorize-url")"
-  state="$(printf '%s' "$authorize_url" | ${pkgs.gnused}/bin/sed -n 's/.*[?&]state=\([^&]*\).*/\1/p')"
-  if [ -z "$state" ]; then
-    echo "authorize URL is missing the OAuth state parameter:" >&2
-    printf '%s\n' "$authorize_url" >&2
-    kill "$login_pid" 2>/dev/null || true
-    exit 1
-  fi
-
-  # The probe under test: an IPv4-only client must reach the callback server.
-  # A connection failure here is the exact regression this check pins down
-  # (server bound to ::1 only).
-  http_status=0
-  if ! http_status="$(${pkgs.curl}/bin/curl --silent --show-error --max-time 10 \
-    --output "$TMPDIR/callback-body" --write-out '%{http_code}' \
-    "http://127.0.0.1:8765/auth/callback?code=probe&state=mismatch-$state")"; then
-    echo "callback probe could not connect to 127.0.0.1:8765; the login server is not bound on the IPv4 loopback" >&2
-    cat "$TMPDIR/login-output" >&2
-    kill "$login_pid" 2>/dev/null || true
-    exit 1
-  fi
-
-  if [ "$http_status" != "400" ]; then
-    echo "expected HTTP 400 for a state-mismatch callback, got $http_status" >&2
-    cat "$TMPDIR/callback-body" >&2
-    kill "$login_pid" 2>/dev/null || true
-    exit 1
-  fi
-  if ! ${pkgs.gnugrep}/bin/grep -q 'state mismatch' "$TMPDIR/callback-body"; then
-    echo "callback response body missing the expected state-mismatch message:" >&2
-    cat "$TMPDIR/callback-body" >&2
-    kill "$login_pid" 2>/dev/null || true
-    exit 1
-  fi
-
-  # The rejected callback must settle the login promise: the CLI exits
-  # nonzero instead of waiting for the five-minute login timeout.
-  tries=0
-  while kill -0 "$login_pid" 2>/dev/null; do
-    tries=$((tries + 1))
-    if [ "$tries" -gt 30 ]; then
-      echo "logseq-cli login still running 30s after the rejected callback" >&2
-      cat "$TMPDIR/login-output" >&2
-      kill "$login_pid" 2>/dev/null || true
+    if [ "$http_status" != "400" ]; then
+      echo "$family: expected HTTP 400 for a state-mismatch callback, got $http_status" >&2
+      cat "$dir/callback-body" >&2
       exit 1
     fi
-    sleep 1
-  done
-  login_status=0
-  wait "$login_pid" || login_status=$?
-  if [ "$login_status" -eq 0 ]; then
-    echo "logseq-cli login exited 0 after a state-mismatch callback" >&2
-    cat "$TMPDIR/login-output" >&2
-    exit 1
-  fi
-  if ! ${pkgs.gnugrep}/bin/grep -Eq 'invalid-callback-state|state mismatch' "$TMPDIR/login-output"; then
-    echo "logseq-cli login output missing the state-mismatch error:" >&2
-    cat "$TMPDIR/login-output" >&2
-    exit 1
+    if ! ${pkgs.gnugrep}/bin/grep -q 'state mismatch' "$dir/callback-body"; then
+      echo "$family: callback response body missing the expected state-mismatch message:" >&2
+      cat "$dir/callback-body" >&2
+      exit 1
+    fi
+
+    # The rejected callback must settle the login promise: the CLI exits
+    # nonzero instead of waiting for the five-minute login timeout.
+    tries=0
+    while kill -0 "$login_pid" 2>/dev/null; do
+      tries=$((tries + 1))
+      if [ "$tries" -gt 30 ]; then
+        echo "$family: logseq-cli login still running 30s after the rejected callback" >&2
+        cat "$dir/login-output" >&2
+        exit 1
+      fi
+      sleep 1
+    done
+    login_status=0
+    wait "$login_pid" || login_status=$?
+    login_pid=""
+    if [ "$login_status" -eq 0 ]; then
+      echo "$family: logseq-cli login exited 0 after a state-mismatch callback" >&2
+      cat "$dir/login-output" >&2
+      exit 1
+    fi
+    if ! ${pkgs.gnugrep}/bin/grep -Eq 'invalid-callback-state|state mismatch' "$dir/login-output"; then
+      echo "$family: logseq-cli login output missing the state-mismatch error:" >&2
+      cat "$dir/login-output" >&2
+      exit 1
+    fi
+  }
+
+  (
+    set -euo pipefail
+    probe_family ipv4 "http://127.0.0.1:8765/auth/callback"
+  )
+
+  ipv6_probe_status=0
+  ${pkgs.nodejs}/bin/node <<'EOF' || ipv6_probe_status=$?
+  const net = require("net");
+  const server = net.createServer();
+  server.once("error", (error) => {
+    if (error && (error.code === "EAFNOSUPPORT" || error.code === "EADDRNOTAVAIL")) {
+      process.exit(42);
+    }
+    console.error(error);
+    process.exit(1);
+  });
+  server.listen(0, "::1", () => server.close(() => process.exit(0)));
+  EOF
+  if [ "$ipv6_probe_status" -eq 0 ]; then
+    (
+      set -euo pipefail
+      probe_family ipv6 "http://[::1]:8765/auth/callback"
+    )
+  elif [ "$ipv6_probe_status" -eq 42 ]; then
+    echo "skipping IPv6 loopback probe because ::1 is unavailable in this build sandbox" >&2
+  else
+    echo "failed to determine IPv6 loopback availability" >&2
+    exit "$ipv6_probe_status"
   fi
 
   touch $out

--- a/patches/logseq-cli-auth-bind-ipv4-loopback.patch
+++ b/patches/logseq-cli-auth-bind-ipv4-loopback.patch
@@ -1,53 +1,288 @@
-Bind the CLI OAuth callback servers to the IPv4 loopback literal.
+Bind the CLI OAuth callback servers to both loopback address families.
 
 logseq.cli.auth listens with (.listen server 8765 "localhost"). Node resolves
 the host with dns.lookup and binds only the first returned address, which is
-::1 on systems whose hosts file lists the IPv6 loopback first. Browsers with
-IPv6 DNS disabled (for example LibreWolf with network.dns.disableIPv6=true)
-resolve localhost to 127.0.0.1 only, get connection refused, and the login
-callback never reaches the CLI, which keeps waiting until the login timeout.
+often ::1 on systems whose hosts file lists the IPv6 loopback first. Browsers
+resolve localhost independently, and browser IPv6 policy can make the callback
+connect to the other loopback family. When that happens, the OAuth callback
+never reaches the CLI, which keeps waiting until the login timeout.
 
-Fix: bind 127.0.0.1 explicitly, following RFC 8252 section 8.3. Browsers that
-prefer ::1 fall back to the next loopback address on refusal, and the
-redirect URI keeps the "localhost" host registered with the Cognito client.
+Fix: keep the "localhost" redirect URI registered with the Cognito client, but
+bind explicit 127.0.0.1 and ::1 listeners for the same callback handler. This
+keeps the listener loopback-only, avoids wildcard :: or omitted-host binding,
+and lets the browser choose either localhost address family. If IPv6 loopback
+is unavailable on a system, the IPv4 listener still starts.
 
-Removal condition: drop this patch when upstream binds an explicit loopback
-literal (or dual-binds both families) in src/main/logseq/cli/auth.cljs. A
-failed strict apply in the nightly build or the CLI build is the drift signal.
+Removal condition: drop this patch when upstream binds explicit loopback
+literals for both families, or switches the Cognito app client to IP-literal
+redirect URIs and uses the matching literal for the selected listener, in
+src/main/logseq/cli/auth.cljs. A failed strict apply in the nightly build or
+the CLI build is the drift signal.
 
 diff --git a/src/main/logseq/cli/auth.cljs b/src/main/logseq/cli/auth.cljs
-index d901975..33927c6 100644
+index d901975..5acee54 100644
 --- a/src/main/logseq/cli/auth.cljs
 +++ b/src/main/logseq/cli/auth.cljs
-@@ -17,6 +17,13 @@
+@@ -17,6 +17,12 @@
  (def ^:private logout-complete-path "/logout-complete")
  (def ^:private callback-host "localhost")
  (def ^:private callback-port 8765)
-+;; Bind the loopback IP literal instead of "localhost": node binds only the
-+;; first address the resolver returns (often ::1), while browsers with IPv6
-+;; disabled connect to 127.0.0.1 only, so the OAuth redirect can target an
-+;; address family the server never bound. RFC 8252 section 8.3 recommends
-+;; loopback IP literals. The redirect URI keeps the "localhost" host that
-+;; the Cognito app client registers.
-+(def ^:private callback-bind-address "127.0.0.1")
++;; Keep the redirect URI host as "localhost" because the Cognito app client
++;; registers that exact callback URL, but bind explicit loopback literals so
++;; browsers can resolve localhost to either address family.
++(def ^:private callback-bind-addresses ["127.0.0.1" "::1"])
++(def ^:private callback-bind-unavailable-error-codes #{"EAFNOSUPPORT"
++                                                       "EADDRNOTAVAIL"})
  (def ^:private auth-provider "cognito")
  (def ^:private default-scope "email openid phone")
  (def ^:private token-endpoint-path "/oauth2/token")
-@@ -258,7 +265,7 @@
-                               (reject (ex-info "failed to start login callback server"
-                                                {:code :login-callback-server-start-failed}
-                                                error))))
+@@ -194,6 +200,61 @@
+                                  (resolve true)))))
+     (p/resolved true)))
+
++(defn- stop-servers!
++  [servers]
++  (if (seq servers)
++    (-> (p/all (map stop-server! servers))
++        (p/then (fn [_] true)))
++    (p/resolved true)))
++
++(defn- callback-bind-unavailable-error?
++  [error]
++  (contains? callback-bind-unavailable-error-codes (.-code error)))
++
++(defn- listen-callback-server!
++  [handler host]
++  (p/create
++   (fn [resolve _reject]
++     (let [server (.createServer http handler)
++           on-error (fn [error]
++                      (resolve {:host host
++                                :error error
++                                :unavailable? (callback-bind-unavailable-error? error)}))]
++       (.once server "error" on-error)
++       (.listen server callback-port host
++                (fn []
++                  (.off server "error" on-error)
++                  (resolve {:host host
++                            :server server
++                            :port (.-port (.address server))})))))))
++
++(defn- start-callback-servers!
++  [handler error-code]
++  (p/let [results (p/all (map #(listen-callback-server! handler %)
++                              callback-bind-addresses))
++          servers (->> results (keep :server) vec)
++          fatal-error (first (filter #(and (:error %) (not (:unavailable? %)))
++                                     results))]
++    (cond
++      fatal-error
++      (-> (stop-servers! servers)
++          (p/then (fn [_]
++                    (p/rejected
++                     (ex-info "failed to start callback server"
++                              {:code error-code
++                               :host (:host fatal-error)}
++                              (:error fatal-error))))))
++
++      (empty? servers)
++      (p/rejected
++       (ex-info "failed to start callback server"
++                {:code error-code
++                 :hosts callback-bind-addresses}))
++
++      :else
++      (p/resolved {:servers servers
++                   :port callback-port}))))
++
+ (defn start-login-callback-server!
+   [{:keys [state login-timeout-ms]}]
+   (p/create
+@@ -208,70 +269,65 @@
+                        (reset! settled? true)
+                        (when-let [{:keys [resolve reject]} @callback-handlers]
+                          ((if (= kind :resolve) resolve reject) payload))))
+-           server (.createServer http
+-                                 (fn [^js req ^js res]
+-                                   (let [url (js/URL. (str "http://" callback-host (.-url req)))
+-                                         pathname (.-pathname url)
+-                                         params (.-searchParams url)
+-                                         code (.get params "code")
+-                                         callback-state (.get params "state")
+-                                         error-code (.get params "error")]
+-                                     (cond
+-                                       (not= redirect-path pathname)
+-                                       (do
+-                                         (.writeHead res 404 #js {"Content-Type" "text/plain; charset=utf-8"})
+-                                         (.end res "Not found"))
+-
+-                                       (seq error-code)
+-                                       (do
+-                                         (.writeHead res 400 #js {"Content-Type" "text/plain; charset=utf-8"})
+-                                         (.end res "Login failed. You can return to the CLI.")
+-                                         (finish! :reject (ex-info "login callback returned oauth error"
+-                                                                   {:code :login-callback-error
+-                                                                    :oauth-error error-code})))
+-
+-                                       (not= state callback-state)
+-                                       (do
+-                                         (.writeHead res 400 #js {"Content-Type" "text/plain; charset=utf-8"})
+-                                         (.end res "Login failed due to state mismatch. Return to the CLI and retry.")
+-                                         (finish! :reject (ex-info "login callback state mismatch"
+-                                                                   {:code :invalid-callback-state})))
+-
+-                                       (not (seq code))
+-                                       (do
+-                                         (.writeHead res 400 #js {"Content-Type" "text/plain; charset=utf-8"})
+-                                         (.end res "Login failed because the callback did not include a code.")
+-                                         (finish! :reject (ex-info "missing authorization code"
+-                                                                   {:code :missing-callback-code})))
+-
+-                                       :else
+-                                       (do
+-                                         (.writeHead res 200 #js {"Content-Type" "text/plain; charset=utf-8"})
+-                                         (.end res "Login successful. You can return to the CLI.")
+-                                         (finish! :resolve {:code code}))))))
++           handler (fn [^js req ^js res]
++                     (let [url (js/URL. (str "http://" callback-host (.-url req)))
++                           pathname (.-pathname url)
++                           params (.-searchParams url)
++                           code (.get params "code")
++                           callback-state (.get params "state")
++                           error-code (.get params "error")]
++                       (cond
++                         (not= redirect-path pathname)
++                         (do
++                           (.writeHead res 404 #js {"Content-Type" "text/plain; charset=utf-8"})
++                           (.end res "Not found"))
++
++                         (seq error-code)
++                         (do
++                           (.writeHead res 400 #js {"Content-Type" "text/plain; charset=utf-8"})
++                           (.end res "Login failed. You can return to the CLI.")
++                           (finish! :reject (ex-info "login callback returned oauth error"
++                                                     {:code :login-callback-error
++                                                      :oauth-error error-code})))
++
++                         (not= state callback-state)
++                         (do
++                           (.writeHead res 400 #js {"Content-Type" "text/plain; charset=utf-8"})
++                           (.end res "Login failed due to state mismatch. Return to the CLI and retry.")
++                           (finish! :reject (ex-info "login callback state mismatch"
++                                                     {:code :invalid-callback-state})))
++
++                         (not (seq code))
++                         (do
++                           (.writeHead res 400 #js {"Content-Type" "text/plain; charset=utf-8"})
++                           (.end res "Login failed because the callback did not include a code.")
++                           (finish! :reject (ex-info "missing authorization code"
++                                                     {:code :missing-callback-code})))
++
++                         :else
++                         (do
++                           (.writeHead res 200 #js {"Content-Type" "text/plain; charset=utf-8"})
++                           (.end res "Login successful. You can return to the CLI.")
++                           (finish! :resolve {:code code})))))
+            timeout-id (js/setTimeout (fn []
+                                        (finish! :reject (ex-info "login callback timed out"
+                                                                  {:code :login-timeout})))
+                                      (or login-timeout-ms default-login-timeout-ms))]
+-       (.on server "error" (fn [error]
+-                              (js/clearTimeout timeout-id)
+-                              (reject (ex-info "failed to start login callback server"
+-                                               {:code :login-callback-server-start-failed}
+-                                               error))))
 -       (.listen server callback-port callback-host
-+       (.listen server callback-port callback-bind-address
-                 (fn []
-                   (let [address (.address server)
-                         port (.-port address)
-@@ -308,7 +315,7 @@
-                               (reject (ex-info "failed to start logout callback server"
-                                                {:code :logout-callback-server-start-failed}
-                                                error))))
+-                (fn []
+-                  (let [address (.address server)
+-                        port (.-port address)
+-                        redirect-uri (str "http://" callback-host ":" port redirect-path)]
+-                    (resolve {:port port
+-                              :redirect-uri redirect-uri
+-                              :wait! (fn []
+-                                       (-> callback-promise
+-                                           (p/finally (fn []
+-                                                        (js/clearTimeout timeout-id)))))
+-                              :stop! (fn []
+-                                       (js/clearTimeout timeout-id)
+-                                       (stop-server! server))}))))))))
++       (-> (start-callback-servers! handler :login-callback-server-start-failed)
++           (p/then (fn [{:keys [servers port]}]
++                     (let [redirect-uri (str "http://" callback-host ":" port redirect-path)]
++                       (resolve {:port port
++                                 :redirect-uri redirect-uri
++                                 :wait! (fn []
++                                          (-> callback-promise
++                                              (p/finally (fn []
++                                                           (js/clearTimeout timeout-id)))))
++                                 :stop! (fn []
++                                          (js/clearTimeout timeout-id)
++                                          (stop-servers! servers))}))))
++           (p/catch (fn [error]
++                      (js/clearTimeout timeout-id)
++                      (reject error))))))))
+
+ (defn start-logout-complete-server!
+   [{:keys [logout-timeout-ms]}]
+@@ -287,37 +343,34 @@
+                        (reset! settled? true)
+                        (when-let [{:keys [resolve reject]} @callback-handlers]
+                          ((if (= kind :resolve) resolve reject) payload))))
+-           server (.createServer http
+-                                 (fn [^js req ^js res]
+-                                   (let [url (js/URL. (str "http://" callback-host (.-url req)))
+-                                         pathname (.-pathname url)]
+-                                     (if (= logout-complete-path pathname)
+-                                       (do
+-                                         (.writeHead res 200 #js {"Content-Type" "text/plain; charset=utf-8"})
+-                                         (.end res "Logout successful. You can return to the CLI.")
+-                                         (finish! :resolve true))
+-                                       (do
+-                                         (.writeHead res 404 #js {"Content-Type" "text/plain; charset=utf-8"})
+-                                         (.end res "Not found"))))))
++           handler (fn [^js req ^js res]
++                     (let [url (js/URL. (str "http://" callback-host (.-url req)))
++                           pathname (.-pathname url)]
++                       (if (= logout-complete-path pathname)
++                         (do
++                           (.writeHead res 200 #js {"Content-Type" "text/plain; charset=utf-8"})
++                           (.end res "Logout successful. You can return to the CLI.")
++                           (finish! :resolve true))
++                         (do
++                           (.writeHead res 404 #js {"Content-Type" "text/plain; charset=utf-8"})
++                           (.end res "Not found")))))
+            timeout-id (js/setTimeout (fn []
+                                        (finish! :reject (ex-info "logout callback timed out"
+                                                                  {:code :logout-timeout})))
+                                      (or logout-timeout-ms default-logout-timeout-ms))]
+-       (.on server "error" (fn [error]
+-                              (js/clearTimeout timeout-id)
+-                              (reject (ex-info "failed to start logout callback server"
+-                                               {:code :logout-callback-server-start-failed}
+-                                               error))))
 -       (.listen server callback-port callback-host
-+       (.listen server callback-port callback-bind-address
-                 (fn []
-                   (resolve {:logout-uri (logout-complete-uri)
-                             :wait! (fn []
+-                (fn []
+-                  (resolve {:logout-uri (logout-complete-uri)
+-                            :wait! (fn []
+-                                     (-> callback-promise
+-                                         (p/finally (fn []
+-                                                      (js/clearTimeout timeout-id)))))
+-                            :stop! (fn []
+-                                     (js/clearTimeout timeout-id)
+-                                     (stop-server! server))})))))))
++       (-> (start-callback-servers! handler :logout-callback-server-start-failed)
++           (p/then (fn [{:keys [servers]}]
++                     (resolve {:logout-uri (logout-complete-uri)
++                               :wait! (fn []
++                                        (-> callback-promise
++                                            (p/finally (fn []
++                                                         (js/clearTimeout timeout-id)))))
++                               :stop! (fn []
++                                        (js/clearTimeout timeout-id)
++                                        (stop-servers! servers))})))
++           (p/catch (fn [error]
++                      (js/clearTimeout timeout-id)
++                      (reject error))))))))
+
+ (defn- browser-open-command
+   [platform url]

--- a/patches/logseq-cli-auth-bind-ipv4-loopback.patch
+++ b/patches/logseq-cli-auth-bind-ipv4-loopback.patch
@@ -36,7 +36,7 @@ index d901975..5acee54 100644
  (def ^:private auth-provider "cognito")
  (def ^:private default-scope "email openid phone")
  (def ^:private token-endpoint-path "/oauth2/token")
-@@ -194,6 +200,61 @@
+@@ -194,6 +200,60 @@
                                   (resolve true)))))
      (p/resolved true)))
 
@@ -97,7 +97,7 @@ index d901975..5acee54 100644
  (defn start-login-callback-server!
    [{:keys [state login-timeout-ms]}]
    (p/create
-@@ -208,70 +269,65 @@
+@@ -208,70 +268,65 @@
                         (reset! settled? true)
                         (when-let [{:keys [resolve reject]} @callback-handlers]
                           ((if (= kind :resolve) resolve reject) payload))))
@@ -223,7 +223,7 @@ index d901975..5acee54 100644
 
  (defn start-logout-complete-server!
    [{:keys [logout-timeout-ms]}]
-@@ -287,37 +343,34 @@
+@@ -287,37 +342,34 @@
                         (reset! settled? true)
                         (when-let [{:keys [resolve reject]} @callback-handlers]
                           ((if (= kind :resolve) resolve reject) payload))))

--- a/patches/logseq-cli-auth-bind-ipv4-loopback.patch
+++ b/patches/logseq-cli-auth-bind-ipv4-loopback.patch
@@ -36,7 +36,7 @@ index d901975..5acee54 100644
  (def ^:private auth-provider "cognito")
  (def ^:private default-scope "email openid phone")
  (def ^:private token-endpoint-path "/oauth2/token")
-@@ -194,6 +200,60 @@
+@@ -194,6 +200,71 @@
                                   (resolve true)))))
      (p/resolved true)))
 
@@ -56,13 +56,19 @@ index d901975..5acee54 100644
 +  (p/create
 +   (fn [resolve _reject]
 +     (let [server (.createServer http handler)
++           bound? (atom false)
 +           on-error (fn [error]
-+                      (resolve {:host host
-+                                :error error
-+                                :unavailable? (callback-bind-unavailable-error? error)}))]
++                      (if @bound?
++                        (js/console.error
++                         (str "logseq-cli callback server error after bind on " host ": ")
++                         error)
++                        (resolve {:host host
++                                  :error error
++                                  :unavailable? (callback-bind-unavailable-error? error)})))]
 +       (.on server "error" on-error)
 +       (.listen server callback-port host
 +                (fn []
++                  (reset! bound? true)
 +                  (resolve {:host host
 +                            :server server
 +                            :port (.-port (.address server))})))))))
@@ -88,7 +94,12 @@ index d901975..5acee54 100644
 +      (p/rejected
 +       (ex-info "failed to start callback server"
 +                {:code error-code
-+                 :hosts callback-bind-addresses}))
++                 :hosts callback-bind-addresses
++                 :errors (mapv (fn [result]
++                                 {:host (:host result)
++                                  :code (some-> (:error result) .-code)
++                                  :message (some-> (:error result) .-message)})
++                               results)}))
 +
 +      :else
 +      (p/resolved {:servers servers
@@ -97,7 +108,7 @@ index d901975..5acee54 100644
  (defn start-login-callback-server!
    [{:keys [state login-timeout-ms]}]
    (p/create
-@@ -208,70 +268,65 @@
+@@ -208,70 +279,65 @@
                         (reset! settled? true)
                         (when-let [{:keys [resolve reject]} @callback-handlers]
                           ((if (= kind :resolve) resolve reject) payload))))
@@ -223,7 +234,7 @@ index d901975..5acee54 100644
 
  (defn start-logout-complete-server!
    [{:keys [logout-timeout-ms]}]
-@@ -287,37 +342,34 @@
+@@ -287,37 +353,34 @@
                         (reset! settled? true)
                         (when-let [{:keys [resolve reject]} @callback-handlers]
                           ((if (= kind :resolve) resolve reject) payload))))

--- a/patches/logseq-cli-auth-bind-ipv4-loopback.patch
+++ b/patches/logseq-cli-auth-bind-ipv4-loopback.patch
@@ -43,7 +43,7 @@ index d901975..5acee54 100644
 +(defn- stop-servers!
 +  [servers]
 +  (if (seq servers)
-+    (-> (p/all (map stop-server! servers))
++    (-> (p/all (mapv stop-server! servers))
 +        (p/then (fn [_] true)))
 +    (p/resolved true)))
 +
@@ -60,18 +60,17 @@ index d901975..5acee54 100644
 +                      (resolve {:host host
 +                                :error error
 +                                :unavailable? (callback-bind-unavailable-error? error)}))]
-+       (.once server "error" on-error)
++       (.on server "error" on-error)
 +       (.listen server callback-port host
 +                (fn []
-+                  (.off server "error" on-error)
 +                  (resolve {:host host
 +                            :server server
 +                            :port (.-port (.address server))})))))))
 +
 +(defn- start-callback-servers!
 +  [handler error-code]
-+  (p/let [results (p/all (map #(listen-callback-server! handler %)
-+                              callback-bind-addresses))
++  (p/let [results (p/all (mapv #(listen-callback-server! handler %)
++                               callback-bind-addresses))
 +          servers (->> results (keep :server) vec)
 +          fatal-error (first (filter #(and (:error %) (not (:unavailable? %)))
 +                                     results))]

--- a/scripts/test-cli-login-loopback.sh
+++ b/scripts/test-cli-login-loopback.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+if [ -f .env ]; then
+  had_nounset=0
+  case "$-" in
+  *u*)
+    had_nounset=1
+    set +u
+    ;;
+  esac
+  set -a
+  # shellcheck disable=SC1091
+  . ./.env
+  set +a
+  if [ "$had_nounset" -eq 1 ]; then
+    set -u
+  fi
+fi
+
+login_timeout_ms="${LOGSEQ_CLI_LOGIN_TIMEOUT_MS:-120000}"
+
+if [ -n "${LOGSEQ_CLI_BIN:-}" ]; then
+  cli=("$LOGSEQ_CLI_BIN")
+elif [ -n "${LOGSEQ_CLI_OUT:-}" ] && [ -x "$LOGSEQ_CLI_OUT/bin/logseq-cli" ]; then
+  cli=("$LOGSEQ_CLI_OUT/bin/logseq-cli")
+else
+  logseq_cli_out="$(nix build --no-link --print-out-paths .#logseq-cli)"
+  cli=("$logseq_cli_out/bin/logseq-cli")
+fi
+
+make_opener_stub() {
+  local stub="$1"
+
+  cat >"$stub" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$1" >"$TMPDIR/authorize-url.tmp"
+mv "$TMPDIR/authorize-url.tmp" "$TMPDIR/authorize-url"
+EOF
+  chmod +x "$stub"
+}
+
+wait_for_authorize_url() {
+  local dir="$1"
+  local pid="$2"
+  local tries
+
+  tries=0
+  while [ ! -s "$dir/authorize-url" ]; do
+    tries=$((tries + 1))
+    if [ "$tries" -gt 120 ]; then
+      echo "logseq-cli login did not produce an authorize URL within 120s" >&2
+      cat "$dir/login-output" >&2
+      kill "$pid" 2>/dev/null || true
+      return 1
+    fi
+
+    if ! kill -0 "$pid" 2>/dev/null; then
+      echo "logseq-cli login exited before opening the browser" >&2
+      cat "$dir/login-output" >&2
+      return 1
+    fi
+
+    sleep 1
+  done
+}
+
+extract_state() {
+  sed -n 's/.*[?&]state=\([^&]*\).*/\1/p' "$1"
+}
+
+probe_family() {
+  local family="$1"
+  local curl_resolve="$2"
+  local test_root="$3"
+  local dir="$test_root/$family"
+  local login_pid
+  local authorize_url
+  local state
+  local callback_url
+  local http_status
+  local login_status
+
+  mkdir -p "$dir/bin" "$dir/home" "$dir/cache"
+  make_opener_stub "$dir/bin/xdg-open"
+  ln -s xdg-open "$dir/bin/open"
+
+  HOME="$dir/home" \
+    TMPDIR="$dir" \
+    XDG_CACHE_HOME="$dir/cache" \
+    PATH="$dir/bin:$PATH" \
+    LOGSEQ_CLI_LOGIN_TIMEOUT_MS="$login_timeout_ms" \
+    "${cli[@]}" login >"$dir/login-output" 2>&1 &
+  login_pid=$!
+
+  if ! wait_for_authorize_url "$dir" "$login_pid"; then
+    return 1
+  fi
+
+  authorize_url="$(cat "$dir/authorize-url")"
+  state="$(extract_state "$dir/authorize-url")"
+  if [ -z "$state" ]; then
+    echo "$family: authorize URL is missing the OAuth state parameter" >&2
+    printf '%s\n' "$authorize_url" >&2
+    kill "$login_pid" 2>/dev/null || true
+    return 1
+  fi
+
+  callback_url="http://localhost:8765/auth/callback?code=probe&state=mismatch-$state"
+
+  if ! http_status="$(curl --silent --show-error --noproxy '*' --max-time 10 \
+    --resolve "$curl_resolve" \
+    --output "$dir/callback-body" \
+    --write-out '%{http_code}' \
+    "$callback_url")"; then
+    echo "$family: callback could not connect through $curl_resolve" >&2
+    cat "$dir/login-output" >&2
+    kill "$login_pid" 2>/dev/null || true
+    return 1
+  fi
+
+  if [ "$http_status" != "400" ]; then
+    echo "$family: expected HTTP 400 for a state-mismatch callback, got $http_status" >&2
+    cat "$dir/callback-body" >&2
+    kill "$login_pid" 2>/dev/null || true
+    return 1
+  fi
+
+  if ! grep -q 'state mismatch' "$dir/callback-body"; then
+    echo "$family: callback body did not contain the expected state-mismatch message" >&2
+    cat "$dir/callback-body" >&2
+    kill "$login_pid" 2>/dev/null || true
+    return 1
+  fi
+
+  login_status=0
+  wait "$login_pid" || login_status=$?
+  if [ "$login_status" -eq 0 ]; then
+    echo "$family: login exited 0 after a state-mismatch callback" >&2
+    cat "$dir/login-output" >&2
+    return 1
+  fi
+
+  if ! grep -Eq 'invalid-callback-state|state mismatch' "$dir/login-output"; then
+    echo "$family: login output did not contain the expected state-mismatch error" >&2
+    cat "$dir/login-output" >&2
+    return 1
+  fi
+
+  echo "$family: callback server reachable through $curl_resolve"
+}
+
+test_root="$(mktemp -d "${TMPDIR:-/tmp}/logseq-cli-loopback-test.XXXXXXXXXX")"
+status=0
+
+echo "test root: $test_root"
+echo "cli: ${cli[*]}"
+
+probe_family ipv4 'localhost:8765:127.0.0.1' "$test_root" || status=1
+probe_family ipv6 'localhost:8765:[::1]' "$test_root" || status=1
+
+if [ "$status" -ne 0 ]; then
+  echo "one or more loopback callback probes failed" >&2
+else
+  echo "both loopback callback probes passed"
+fi
+
+exit "$status"

--- a/scripts/test-cli-login-loopback.sh
+++ b/scripts/test-cli-login-loopback.sh
@@ -71,7 +71,7 @@ wait_for_authorize_url() {
 }
 
 extract_state() {
-  sed -n 's/.*[?&]state=\([^&]*\).*/\1/p' "$1"
+  sed -n 's/^.*[?&]state=\([^&]*\).*$/\1/p' "$1" | tr -d '\r'
 }
 
 probe_family() {
@@ -79,14 +79,11 @@ probe_family() {
   local curl_resolve="$2"
   local test_root="$3"
   local dir="$test_root/$family"
-  local login_pid=""
   local authorize_url
   local state
   local callback_url
   local http_status
   local login_status
-
-  trap 'if [ -n "${login_pid:-}" ]; then kill "$login_pid" 2>/dev/null || true; wait "$login_pid" 2>/dev/null || true; login_pid=""; fi' EXIT
 
   mkdir -p "$dir/bin" "$dir/home" "$dir/cache"
   make_opener_stub "$dir/bin/xdg-open"
@@ -160,6 +157,8 @@ run_probe_family() {
   set +e
   (
     set -e
+    login_pid=""
+    trap 'if [ -n "${login_pid:-}" ]; then kill "$login_pid" 2>/dev/null || true; wait "$login_pid" 2>/dev/null || true; login_pid=""; fi' EXIT
     probe_family "$@"
   )
   probe_status=$?

--- a/scripts/test-cli-login-loopback.sh
+++ b/scripts/test-cli-login-loopback.sh
@@ -86,7 +86,7 @@ probe_family() {
   local http_status
   local login_status
 
-  trap 'if [ -n "${login_pid:-}" ]; then kill "$login_pid" 2>/dev/null || true; wait "$login_pid" 2>/dev/null || true; login_pid=""; fi' RETURN
+  trap 'if [ -n "${login_pid:-}" ]; then kill "$login_pid" 2>/dev/null || true; wait "$login_pid" 2>/dev/null || true; login_pid=""; fi' EXIT
 
   mkdir -p "$dir/bin" "$dir/home" "$dir/cache"
   make_opener_stub "$dir/bin/xdg-open"
@@ -154,6 +154,22 @@ probe_family() {
   echo "$family: callback server reachable through $curl_resolve"
 }
 
+run_probe_family() {
+  local probe_status
+
+  set +e
+  (
+    set -e
+    probe_family "$@"
+  )
+  probe_status=$?
+  set -e
+
+  if [ "$probe_status" -ne 0 ]; then
+    status=1
+  fi
+}
+
 test_root="$(mktemp -d "${TMPDIR:-/tmp}/logseq-cli-loopback-test.XXXXXXXXXX")"
 trap 'rm -rf -- "$test_root"' EXIT
 status=0
@@ -161,8 +177,8 @@ status=0
 echo "test root: $test_root"
 echo "cli: ${cli[*]}"
 
-probe_family ipv4 'localhost:8765:127.0.0.1' "$test_root" || status=1
-probe_family ipv6 'localhost:8765:[::1]' "$test_root" || status=1
+run_probe_family ipv4 'localhost:8765:127.0.0.1' "$test_root"
+run_probe_family ipv6 'localhost:8765:[::1]' "$test_root"
 
 if [ "$status" -ne 0 ]; then
   echo "one or more loopback callback probes failed" >&2

--- a/scripts/test-cli-login-loopback.sh
+++ b/scripts/test-cli-login-loopback.sh
@@ -79,12 +79,14 @@ probe_family() {
   local curl_resolve="$2"
   local test_root="$3"
   local dir="$test_root/$family"
-  local login_pid
+  local login_pid=""
   local authorize_url
   local state
   local callback_url
   local http_status
   local login_status
+
+  trap 'if [ -n "${login_pid:-}" ]; then kill "$login_pid" 2>/dev/null || true; wait "$login_pid" 2>/dev/null || true; login_pid=""; fi' RETURN
 
   mkdir -p "$dir/bin" "$dir/home" "$dir/cache"
   make_opener_stub "$dir/bin/xdg-open"
@@ -107,7 +109,6 @@ probe_family() {
   if [ -z "$state" ]; then
     echo "$family: authorize URL is missing the OAuth state parameter" >&2
     printf '%s\n' "$authorize_url" >&2
-    kill "$login_pid" 2>/dev/null || true
     return 1
   fi
 
@@ -120,26 +121,24 @@ probe_family() {
     "$callback_url")"; then
     echo "$family: callback could not connect through $curl_resolve" >&2
     cat "$dir/login-output" >&2
-    kill "$login_pid" 2>/dev/null || true
     return 1
   fi
 
   if [ "$http_status" != "400" ]; then
     echo "$family: expected HTTP 400 for a state-mismatch callback, got $http_status" >&2
     cat "$dir/callback-body" >&2
-    kill "$login_pid" 2>/dev/null || true
     return 1
   fi
 
   if ! grep -q 'state mismatch' "$dir/callback-body"; then
     echo "$family: callback body did not contain the expected state-mismatch message" >&2
     cat "$dir/callback-body" >&2
-    kill "$login_pid" 2>/dev/null || true
     return 1
   fi
 
   login_status=0
   wait "$login_pid" || login_status=$?
+  login_pid=""
   if [ "$login_status" -eq 0 ]; then
     echo "$family: login exited 0 after a state-mismatch callback" >&2
     cat "$dir/login-output" >&2

--- a/scripts/test-cli-login-loopback.sh
+++ b/scripts/test-cli-login-loopback.sh
@@ -156,6 +156,7 @@ probe_family() {
 }
 
 test_root="$(mktemp -d "${TMPDIR:-/tmp}/logseq-cli-loopback-test.XXXXXXXXXX")"
+trap 'rm -rf -- "$test_root"' EXIT
 status=0
 
 echo "test root: $test_root"


### PR DESCRIPTION
## Summary

- replaces the downstream Logseq CLI auth patch with a dual-loopback listener implementation for login and logout callbacks
- keeps `http://localhost:8765/...` redirect URIs because the current Cognito app client rejects `127.0.0.1` and `[::1]` literals
- adds `scripts/test-cli-login-loopback.sh` to exercise both forced callback paths with `curl --resolve`

## Details

The previous patch bound the callback server to `127.0.0.1` only. That fixes browsers that resolve `localhost` to IPv4, but it breaks browsers that resolve `localhost` to `::1` while Cognito still requires the registered `localhost` redirect URI.

The new patch starts separate loopback-only listeners on `127.0.0.1:8765` and `::1:8765`, using the same request handler and shared settlement state. IPv6-unavailable bind errors are tolerated so IPv4-only systems still work, while fatal bind errors still fail loudly.

## Validation

- `git apply --check patches/logseq-cli-auth-bind-ipv4-loopback.patch` against Logseq `0a27a7958718361a320cb022bb1ec9391d2450f1`
- `patch -p1 --dry-run` against Logseq `0a27a7958718361a320cb022bb1ec9391d2450f1`
- `git diff --check -- patches/logseq-cli-auth-bind-ipv4-loopback.patch scripts/test-cli-login-loopback.sh`
- `bash -n scripts/test-cli-login-loopback.sh`
- `nix develop -c pre-commit run --hook-stage pre-commit --files patches/logseq-cli-auth-bind-ipv4-loopback.patch scripts/test-cli-login-loopback.sh`
- `nix build --no-link .#logseq-cli`
- `scripts/test-cli-login-loopback.sh`
- `nix build --no-link .#checks.x86_64-linux.logseq-cli-login-callback`
- pre-push hook: `shellcheck`, `gitleaks`, `trim-trailing-whitespace`
