### PR TITLE
fix(cache): push cliCljDeps FOD and cache aarch64 logseq-cli builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -115,14 +115,20 @@ jobs:
       - name: Update nightly manifest and CLI hashes
         run: bash scripts/update-nightly.sh
 
-      # Realize the architecture-independent CLI FODs with their freshly
-      # resolved hashes so Cachix uploads them; aarch64 jobs substitute these
-      # paths instead of rebuilding them.
-      - name: Seed CLI fixed-output derivations to Cachix
+      # update-nightly.sh already realized these architecture-independent CLI
+      # FODs while resolving their hashes, so a plain `nix build` here rebuilds
+      # nothing and the Cachix post-build-hook (which fires only on a fresh
+      # build) never uploads them. Push the resolved paths explicitly so
+      # aarch64 and cross-nixpkgs consumers substitute them instead of
+      # rebuilding the offline Maven + tools.gitlibs tree.
+      - name: Push CLI fixed-output derivations to Cachix
         run: |
-          nix build --accept-flake-config --print-build-logs \
+          set -euo pipefail
+          nix build --accept-flake-config --print-build-logs --no-link \
+            --print-out-paths \
             .#logseq-cli.cliCljDeps \
-            .#logseq-cli.cliPnpmDeps
+            .#logseq-cli.cliPnpmDeps \
+            | cachix push nix-logseq-git-flake
 
       - name: Configure git
         run: |
@@ -182,6 +188,55 @@ jobs:
             -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 
           git push "$repo_url" HEAD:main
+
+  cache-cli-aarch64:
+    # publish-release caches the x86_64 logseq-cli via `nix flake check`, but
+    # the aarch64 finals are only ever built by validate.yml, which never runs
+    # on the bot's manifest commit (a GITHUB_TOKEN push triggers no workflows).
+    # Build them here on native runners so aarch64 consumers substitute the CLI
+    # instead of compiling the shadow-cljs release locally. The architecture-
+    # independent FODs are already in Cachix from publish-release, so each leg
+    # only compiles cljs:release plus the wrapper. Best-effort: a failure here
+    # does not undo the already-published release.
+    needs: publish-release
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - system: aarch64-linux
+            runner: ubuntu-24.04-arm
+          - system: aarch64-darwin
+            runner: macos-26
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            accept-flake-config = true
+
+      - name: Setup Cachix
+        uses: cachix/cachix-action@v17
+        with:
+          name: nix-logseq-git-flake
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      # cachix-action's post-build-hook pushes these fresh native builds; the
+      # help check doubles as an aarch64 smoke test (doctor + db-worker spawn).
+      - name: Build and push logseq-cli
+        env:
+          SYSTEM: ${{ matrix.system }}
+        run: |
+          set -euo pipefail
+          nix build --accept-flake-config --print-build-logs \
+            ".#packages.${SYSTEM}.logseq-cli" \
+            ".#checks.${SYSTEM}.logseq-cli-help"
 
   report-failure:
     if: ${{ always() && github.event_name == 'schedule' && (needs.build.result != 'success' || needs['publish-release'].result != 'success') }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -268,12 +268,19 @@ jobs:
         if: steps.gate.outputs.run == 'true'
         run: nix flake check --accept-flake-config
 
-      - name: Seed CLI fixed-output derivations to Cachix
+      # update-nightly.sh (above) already realized these FODs, so a plain
+      # `nix build` rebuilds nothing and the Cachix post-build-hook never
+      # uploads them. Push the resolved paths explicitly. Gated on
+      # push_to_cachix, so CACHIX_AUTH_TOKEN is present.
+      - name: Push CLI fixed-output derivations to Cachix
         if: ${{ steps.gate.outputs.run == 'true' && inputs.push_to_cachix }}
         run: |
-          nix build --accept-flake-config --print-build-logs \
+          set -euo pipefail
+          nix build --accept-flake-config --print-build-logs --no-link \
+            --print-out-paths \
             .#logseq-cli.cliCljDeps \
-            .#logseq-cli.cliPnpmDeps
+            .#logseq-cli.cliPnpmDeps \
+            | cachix push nix-logseq-git-flake
 
       - name: Capture regenerated manifest
         if: steps.gate.outputs.run == 'true'

--- a/modules/_packages/logseq-cli/clj-deps.nix
+++ b/modules/_packages/logseq-cli/clj-deps.nix
@@ -7,7 +7,6 @@
   lib,
   src,
   stdenv,
-  version,
 }:
 # Fixed-output derivation that populates a Maven local repository (`m2/`) and
 # Clojure git-deps checkouts (`gitlibs/libs/`) for the `:cljs` alias in
@@ -17,8 +16,14 @@
 # cljc-fsrs, cljs-http-missionary, logseq-schema), so the fetch must happen in
 # an FOD with network access.
 stdenv.mkDerivation {
-  pname = "logseq-cli-clj-deps";
-  inherit version src;
+  # Unversioned name on purpose: this FOD's store path must stay stable across
+  # nightlies so a single Cachix push stays valid until the content
+  # (cliCljDepsHash) actually changes. A per-nightly version churns the path
+  # daily, re-uploading an identical Maven + gitlibs tree and leaving consumers
+  # pinned to an older commit on a cache miss. Mirrors fetchPnpmDeps, which
+  # names cliPnpmDeps `logseq-cli-pnpm-deps` without a version.
+  name = "logseq-cli-clj-deps";
+  inherit src;
 
   nativeBuildInputs = [
     clojure

--- a/modules/_packages/logseq-cli/package.nix
+++ b/modules/_packages/logseq-cli/package.nix
@@ -49,7 +49,6 @@ let
       lib
       src
       stdenv
-      version
       ;
   };
   cliBuilt = import ./build.nix {


### PR DESCRIPTION
## Problem

Downstream `nix build .#logseq-cli` rebuilds the CLI from source instead of substituting it from the
`nix-logseq-git-flake.cachix.org` cache. On x86_64 with the pinned lock the final wrapper is fetched, but any
consumer that must build the wrapper (aarch64, or a different `nixpkgs` via `follows`) re-runs the expensive
offline Maven + `tools.gitlibs` Clojure-deps resolution.

Evidence (cache `*.narinfo` for the paths HEAD evaluates to):

| Path | Cached |
| --- | --- |
| `logseq-cli` wrapper / `logseq-cli-built`, x86_64 | 200 |
| `cliPnpmDeps` (`logseq-cli-pnpm-deps`, stable name) | 200 |
| `cliCljDeps` (`logseq-cli-clj-deps-<version>`, daily name) | **404** |
| `logseq-cli`, aarch64-linux / aarch64-darwin | **404** |

## Root cause

1. **`cliCljDeps` is never pushed.** `scripts/update-nightly.sh` realizes the FOD while resolving its hash (a
   placeholder build Nix reports as a hash mismatch). By the time the "Seed CLI fixed-output derivations to
   Cachix" step runs, the path is already in the store, so `nix build` rebuilds nothing and cachix-action's
   post-build-hook (which fires only after a fresh build) never uploads it. Confirmed in the latest nightly log:
   the seed step ran in ~1.6s emitting only "Git tree is dirty", and the Cachix daemon push list contains the
   wrapper/built/check but neither FOD.
2. **Daily path churn.** `cliPnpmDeps` survives because `fetchPnpmDeps` names it `logseq-cli-pnpm-deps` (no
   version) so one old push stays valid. `cliCljDeps` embedded the per-nightly `version`, so its path changes
   every night and needs a push that never comes.
3. **aarch64 finals are never built in CI.** `publish-release` builds the x86_64 CLI via `nix flake check`; the
   aarch64 finals are only built by `validate.yml`, which never runs on the bot's manifest commit because a
   `GITHUB_TOKEN` push triggers no workflows.

## Changes

- **`nightly.yml`, `pr-build.yml`**: replace the no-op seed step with an explicit `cachix push` of the resolved
  FOD out paths. `cachix push` uploads a valid store path regardless of how it was realized, so it is immune to
  the post-build-hook gap. Left `validate.yml` alone: it builds the FODs fresh (its hook works) and runs on fork
  PRs without `CACHIX_AUTH_TOKEN`, where an explicit push would fail.
- **`clj-deps.nix`, `package.nix`**: drop `version` from the FOD name (now `logseq-cli-clj-deps`) so the path
  stays stable across nightlies. The output is content-addressed by `cliCljDepsHash`, which is unchanged, so the
  manifest is untouched. Verified the path is now unversioned and identical across all three systems.
- **`nightly.yml`**: add a best-effort `cache-cli-aarch64` matrix job (aarch64-linux on `ubuntu-24.04-arm`,
  aarch64-darwin on `macos-26`) that builds and pushes `.#packages.<system>.logseq-cli` after `publish-release`.
  The now-cached architecture-independent FODs mean each leg only compiles `cljs:release` plus the wrapper.

## Rollout

The FOD push and aarch64 cache take effect on the **next nightly** (or a `pr-build` dispatch with
`push_to_cachix=true`). The `clj-deps` rename changes the CLI closure once, so the existing x86_64 cache entry is
stale until the next nightly rebuilds and pushes it.

## Validation

- `nix build .#checks.x86_64-linux.pre-commit-check` (treefmt, actionlint, deadnix, statix, shellcheck, nix-parse
  all pass)
- `nix eval .#logseq-cli.cliCljDeps.outPath` -> unversioned `logseq-cli-clj-deps`, identical on x86_64 and both
  aarch64 systems
- `nix eval` of `.#packages.{aarch64-linux,aarch64-darwin}.logseq-cli` and the `logseq-cli-help` check attrs
- `nix flake show --all-systems`
- `actionlint`; `gitleaks` clean on the commit range

## Notes for reviewer

- Touches `.github/workflows/*`, so the security-review label is attached.
- `cache-cli-aarch64` is intentionally not wired into the `report-failure` / `report-recovery` rolling issue,
  which stays scoped to the release-critical `build` + `publish-release` path. A failed cache leg shows as a red
  job without coupling cache flakiness (e.g. transient macOS runners) to release-health alarms. Happy to wire it
  in if you prefer louder alerting.
