### PR TITLE
ci(cachix): install from flake-pinned nixpkgs instead of cachix.org

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -98,6 +98,7 @@ jobs:
         with:
           name: nix-logseq-git-flake
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          installCommand: nix profile install --inputs-from "$GITHUB_WORKSPACE" nixpkgs#cachix
 
       - name: Publish GitHub release
         env:
@@ -226,6 +227,7 @@ jobs:
         with:
           name: nix-logseq-git-flake
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          installCommand: nix profile install --inputs-from "$GITHUB_WORKSPACE" nixpkgs#cachix
 
       # cachix-action's post-build-hook pushes these fresh native builds; the
       # help check doubles as an aarch64 smoke test (doctor + db-worker spawn).

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -254,6 +254,7 @@ jobs:
         with:
           name: nix-logseq-git-flake
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          installCommand: nix profile install --inputs-from "$GITHUB_WORKSPACE" nixpkgs#cachix
           skipPush: ${{ !inputs.push_to_cachix }}
 
       - name: Regenerate manifest and CLI hashes

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -141,6 +141,7 @@ jobs:
         with:
           name: nix-logseq-git-flake
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          installCommand: nix profile install --inputs-from "$GITHUB_WORKSPACE" nixpkgs#cachix
           skipPush: true
 
       # Tag, notes, and assets come from the RELEASE_* env handoff exported

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           name: nix-logseq-git-flake
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          installCommand: nix profile install --inputs-from "$GITHUB_WORKSPACE" nixpkgs#cachix
 
       - name: Check formatting
         run: nix fmt -- --ci
@@ -72,6 +73,7 @@ jobs:
         with:
           name: nix-logseq-git-flake
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          installCommand: nix profile install --inputs-from "$GITHUB_WORKSPACE" nixpkgs#cachix
 
       - name: Run nix flake check (x86_64-linux)
         run: nix flake check
@@ -99,6 +101,7 @@ jobs:
         with:
           name: nix-logseq-git-flake
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          installCommand: nix profile install --inputs-from "$GITHUB_WORKSPACE" nixpkgs#cachix
 
       - name: Build and smoke-test logseq-cli (aarch64)
         run: |
@@ -147,6 +150,7 @@ jobs:
         with:
           name: nix-logseq-git-flake
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          installCommand: nix profile install --inputs-from "$GITHUB_WORKSPACE" nixpkgs#cachix
 
       - name: Build and smoke-test logseq-cli (aarch64-darwin)
         run: |


### PR DESCRIPTION
## Problem

`validate-aarch64-darwin` recurrently fails at the **Setup Cachix** step. The macOS runner times out resolving `cachix.org` while installing the cachix binary:

```
[command]/bin/bash -c nix-env --quiet -j8 -iA cachix -f https://cachix.org/api/v1/install
error: unable to download 'https://cachix.org/api/v1/install': Timeout was
  reached (28) Resolving timed out after 15002 milliseconds
##[error]Action failed with error: Error: The process '/bin/bash' failed with exit code 1
```

The default `cachix-action` install is a direct URL fetch from `cachix.org` with no substituter fallback, so a DNS blip there hard-fails the job. `cache.nixos.org`, `github.com`, and `install.determinate.systems` resolve in the same job, so the failure is specific to `cachix.org` reachability at install time, and it recurs only on the macOS leg.

Failing run: https://github.com/Bad3r/nix-logseq-git-flake/actions/runs/27834878719/job/82380518118

## Fix

Override `installCommand` on every `cachix-action` usage to install cachix from the flake-pinned nixpkgs via `cache.nixos.org`:

```yaml
installCommand: nix profile install --inputs-from "$GITHUB_WORKSPACE" nixpkgs#cachix
```

This reuses the macOS-proven `nix profile install --inputs-from` pattern that `build-desktop.yml` already uses for the OCaml toolchain (e6cae34) and removes the `cachix.org` dependency at install time. cachix is substituted from `cache.nixos.org` instead. Applied to all arches and workflows (validate.yml x4, nightly.yml x2, test-build.yml, pr-build.yml) so the cachix setup does not diverge per runner.

## Validation

- `actionlint` on the four changed workflows: pass
- `nix eval --inputs-from "$PWD" nixpkgs#cachix.name` returns `"cachix-1.11.1"`
- This PR's own `validate-aarch64-darwin` run exercises the new install path on the macOS leg.
