### PR TITLE
fix(logseq-cli): resolve opam #main pins per-nightly via manifest

### DIFF
--- a/data/logseq-nightly.json
+++ b/data/logseq-nightly.json
@@ -18,6 +18,7 @@
   "logseqRev": "186e699528f2cf9c8fae47e5412bdab78f0cbd58",
   "logseqVersion": "2.0.1-alpha+nightly.20260625",
   "cliSrcHash": "sha256-iIIcMmejTW324pKjqPW1xn8UiGuZQqwwnhUO90NqhXU=",
+  "cliOpamPinOverrides": [],
   "cliPnpmDepsHash": "sha256-r68qKxB3jwdMjBCZ7UWyTMoYoO+qaeRUJxhzGd3QtDw=",
   "cliBundlePnpmDepsHash": "sha256-i5zJ+lvhcBF1CA1hFY4SlEg4p6IEfFrNPYTEYiFviiE=",
   "cliCljDepsHash": "sha256-BkZ5NadvDguRFlF43MhULec4YAH9mAGij6ES4ilgumM=",

--- a/lib/loadManifest.nix
+++ b/lib/loadManifest.nix
@@ -5,7 +5,9 @@ let
     foldl'
     fromJSON
     hasAttr
+    isList
     isString
+    match
     readFile
     ;
   inherit (lib) concatStringsSep hasPrefix throwIf;
@@ -17,6 +19,7 @@ let
     "logseqRev"
     "logseqVersion"
     "cliSrcHash"
+    "cliOpamPinOverrides"
     "cliPnpmDepsHash"
     "cliBundlePnpmDepsHash"
     "cliCljDepsHash"
@@ -40,6 +43,22 @@ let
       !hasPrefix "sha256-" parsed.${key}
     ) "Manifest ${key} must begin with sha256- (Nix SRI)." acc;
 
+  # update-nightly.sh resolves each cli/logseq-cli.opam pin-depends entry whose git
+  # ref is a mutable branch into an explicit commit (opam-nix refuses a non-sha1 git
+  # pin in pure evaluation mode). opam-deps.nix rewrites each `from` URL to `to`
+  # before opam-nix reads the file. Require an explicit 40-char sha1 fragment on
+  # every `to` so a stale/branch override cannot reach the pure-eval resolver.
+  pinOverrides = if hasAttr "cliOpamPinOverrides" parsed then parsed.cliOpamPinOverrides else [ ];
+  validatePinOverride =
+    acc: entry:
+    throwIf (!(hasAttr "from" entry && isString entry.from))
+      "Manifest cliOpamPinOverrides entries must carry a string from."
+      (
+        throwIf (
+          !(hasAttr "to" entry && isString entry.to && match ".*#[0-9a-f]{40}" entry.to != null)
+        ) "Manifest cliOpamPinOverrides entries must carry a to URL ending in an explicit 40-char sha1." acc
+      );
+
   # Each per-system desktop asset must carry a string url and an SRI sha256.
   assetSystems = if hasAttr "assets" parsed then attrNames parsed.assets else [ ];
   validateAsset =
@@ -59,11 +78,13 @@ throwIf (missing != [ ]) "Manifest missing required keys: ${concatStringsSep ", 
   throwIf (missingAssetSystems != [ ])
     "Manifest missing required desktop asset systems: ${concatStringsSep ", " missingAssetSystems}"
     (
-      foldl' validateAsset (foldl' validateHash parsed [
-        "cliSrcHash"
-        "cliPnpmDepsHash"
-        "cliBundlePnpmDepsHash"
-        "cliCljDepsHash"
-      ]) assetSystems
+      throwIf (!isList pinOverrides) "Manifest cliOpamPinOverrides must be a list." (
+        foldl' validatePinOverride (foldl' validateAsset (foldl' validateHash parsed [
+          "cliSrcHash"
+          "cliPnpmDepsHash"
+          "cliBundlePnpmDepsHash"
+          "cliCljDepsHash"
+        ]) assetSystems) pinOverrides
+      )
     )
 )

--- a/modules/_packages/logseq-cli/opam-deps.nix
+++ b/modules/_packages/logseq-cli/opam-deps.nix
@@ -1,4 +1,6 @@
 {
+  cliOpamPinOverrides,
+  lib,
   opamNix,
   pkgs,
   src,
@@ -24,7 +26,31 @@
 # compiles from source.
 let
   on = opamNix.lib.${system};
-  baseScope = on.buildOpamProject { inherit pkgs; } "logseq-cli" "${src}/cli" {
+  # Upstream cli/logseq-cli.opam (since logseq/logseq 3684727952e6) pins some
+  # pin-depends (melange-edn, humanize, ...) at a mutable `#main` branch. opam-nix's
+  # fetchGitURL refuses a git pin whose fragment is not a 40-char sha1 in pure
+  # evaluation mode and throws "[opam-nix] a git dependency without an explicit
+  # sha1 is not supported in pure evaluation mode". Native opam (the desktop build
+  # legs) accepts the branch ref, so only this opam-nix path needs explicit revs.
+  # scripts/update-nightly.sh resolves each branch ref to its current commit and
+  # records the rewrites in manifest.cliOpamPinOverrides ({from,to} URL pairs), so
+  # the pin advances with logseqRev every nightly instead of freezing. Apply those
+  # rewrites before opam-nix reads the file. When the override list is empty (every
+  # pin already a sha1) the project is read in place, unchanged.
+  pinRewrites = lib.concatMapStringsSep "\n" (
+    o:
+    "substituteInPlace \"$out/logseq-cli.opam\" --replace-fail ${lib.escapeShellArg o.from} ${lib.escapeShellArg o.to}"
+  ) cliOpamPinOverrides;
+  cliProject =
+    if cliOpamPinOverrides == [ ] then
+      "${src}/cli"
+    else
+      pkgs.runCommandLocal "logseq-cli-opam-project" { } ''
+        cp -R ${src}/cli "$out"
+        chmod -R u+w "$out"
+        ${pinRewrites}
+      '';
+  baseScope = on.buildOpamProject { inherit pkgs; } "logseq-cli" "${cliProject}" {
     ocaml-base-compiler = "5.4.0";
   };
   # melc locates its own stdlib relative to its binary: `melc -where` yields

--- a/modules/_packages/logseq-cli/package.nix
+++ b/modules/_packages/logseq-cli/package.nix
@@ -4,6 +4,7 @@
   clang_20,
   cliBundlePnpmDepsHash,
   cliCljDepsHash,
+  cliOpamPinOverrides,
   cliPnpmDepsHash,
   cliSrcHash,
   cliVersion,
@@ -70,6 +71,8 @@ let
   # OCaml 5.4.0 + melange* + humanize closure for the Melange CLI compile.
   opamDeps = import ./opam-deps.nix {
     inherit
+      cliOpamPinOverrides
+      lib
       opamNix
       pkgs
       src

--- a/modules/_packages/logseq-nightly.nix
+++ b/modules/_packages/logseq-nightly.nix
@@ -24,6 +24,7 @@ let
     inherit (manifest)
       cliBundlePnpmDepsHash
       cliCljDepsHash
+      cliOpamPinOverrides
       cliPnpmDepsHash
       cliSrcHash
       cliVersion

--- a/scripts/update-nightly.sh
+++ b/scripts/update-nightly.sh
@@ -60,6 +60,29 @@ echo "::endgroup::"
 # their current HEAD here so the pin advances every nightly with LOGSEQ_REV instead
 # of freezing at a hardcoded commit. Entries already pinned to a sha1 are left alone,
 # so this self-clears once upstream restores explicit commits.
+#
+# Resolve a branch/tag fragment to a commit sha1 on $remote. awk matches $2
+# exactly because `git ls-remote <pattern>` tail-matches, so a bare `main` also
+# returns refs/heads/feature/main and a positional NR==1 pick could grab the
+# wrong ref. Prefer a branch head, then a peeled annotated tag
+# (refs/tags/<f>^{} is the commit the tag points at; opam-nix needs a commit,
+# not the tag object), then a lightweight tag or an already-qualified ref.
+resolve_ref_sha() {
+  local remote="$1" frag="$2"
+  git ls-remote "$remote" \
+    "refs/heads/$frag" "refs/tags/$frag^{}" "refs/tags/$frag" "$frag" |
+    awk -v f="$frag" '
+      $2 == "refs/heads/" f      { head = $1 }
+      $2 == "refs/tags/" f "^{}" { peeled = $1 }
+      $2 == "refs/tags/" f       { tag = $1 }
+      $2 == f                    { bare = $1 }
+      END {
+        if (head != "")        print head
+        else if (peeled != "") print peeled
+        else if (tag != "")    print tag
+        else if (bare != "")   print bare
+      }'
+}
 echo "::group::Phase 3b: Resolve opam pin-depends branch refs"
 OPAM_RAW_URL="https://raw.githubusercontent.com/logseq/logseq/${LOGSEQ_REV}/cli/logseq-cli.opam"
 OPAM_TMP="$(mktemp)"
@@ -76,7 +99,7 @@ for url in "${PIN_URLS[@]}"; do
   fi
   base="${url%#*}"
   remote="${base#git+}"
-  sha="$(git ls-remote "$remote" "$frag" | awk 'NR==1{print $1}')"
+  sha="$(resolve_ref_sha "$remote" "$frag")"
   if [[ ! $sha =~ ^[0-9a-f]{40}$ ]]; then
     echo "ERROR: could not resolve ${remote} ref ${frag} to a commit sha1" >&2
     exit 1

--- a/scripts/update-nightly.sh
+++ b/scripts/update-nightly.sh
@@ -52,6 +52,42 @@ CLI_VERSION="$LOGSEQ_VERSION"
 echo "  cliVersion=$CLI_VERSION"
 echo "::endgroup::"
 
+# ── Phase 3b: Resolve opam pin-depends branch refs ──────────────────
+# Upstream cli/logseq-cli.opam (logseq/logseq 3684727952e6) pins some deps
+# (melange-edn, humanize, ...) at the mutable `#main` branch. opam-nix refuses a
+# git pin without an explicit 40-char sha1 in pure evaluation mode, so opam-deps.nix
+# rewrites each branch ref to a commit before resolving. Resolve those branches to
+# their current HEAD here so the pin advances every nightly with LOGSEQ_REV instead
+# of freezing at a hardcoded commit. Entries already pinned to a sha1 are left alone,
+# so this self-clears once upstream restores explicit commits.
+echo "::group::Phase 3b: Resolve opam pin-depends branch refs"
+OPAM_RAW_URL="https://raw.githubusercontent.com/logseq/logseq/${LOGSEQ_REV}/cli/logseq-cli.opam"
+OPAM_TMP="$(mktemp)"
+trap 'rm -f "$OPAM_TMP"' EXIT
+curl -fsSL "$OPAM_RAW_URL" -o "$OPAM_TMP"
+CLI_OPAM_PIN_OVERRIDES="[]"
+# pin-depends URLs are the only git+<proto>://...#<frag> tokens; dev-repo carries no
+# fragment and is excluded. `|| true`: no git pins is a valid opam file, not an error.
+mapfile -t PIN_URLS < <(grep -oE 'git\+[a-z]+://[^"#]+#[^"]+' "$OPAM_TMP" | sort -u || true)
+for url in "${PIN_URLS[@]}"; do
+  frag="${url##*#}"
+  if [[ $frag =~ ^[0-9a-f]{40}$ ]]; then
+    continue
+  fi
+  base="${url%#*}"
+  remote="${base#git+}"
+  sha="$(git ls-remote "$remote" "$frag" | awk 'NR==1{print $1}')"
+  if [[ ! $sha =~ ^[0-9a-f]{40}$ ]]; then
+    echo "ERROR: could not resolve ${remote} ref ${frag} to a commit sha1" >&2
+    exit 1
+  fi
+  CLI_OPAM_PIN_OVERRIDES="$(jq -c --arg from "$url" --arg to "${base}#${sha}" \
+    '. + [{ from: $from, to: $to }]' <<<"$CLI_OPAM_PIN_OVERRIDES")"
+  echo "  ${url} -> ${base}#${sha}"
+done
+echo "  cliOpamPinOverrides=$CLI_OPAM_PIN_OVERRIDES"
+echo "::endgroup::"
+
 # ── Phase 4: Write manifest with placeholder hashes ─────────────────
 echo "::group::Phase 4: Write manifest (placeholder pnpm/vendor hashes)"
 PLACEHOLDER="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
@@ -67,6 +103,7 @@ jq -n \
   --arg logseqRev "$LOGSEQ_REV" \
   --arg logseqVersion "$LOGSEQ_VERSION" \
   --arg cliSrcHash "$CLI_SRC_HASH" \
+  --argjson cliOpamPinOverrides "$CLI_OPAM_PIN_OVERRIDES" \
   --arg cliPnpmDepsHash "$PLACEHOLDER" \
   --arg cliBundlePnpmDepsHash "$PLACEHOLDER" \
   --arg cliCljDepsHash "$PLACEHOLDER" \
@@ -82,6 +119,7 @@ jq -n \
     logseqRev: $logseqRev,
     logseqVersion: $logseqVersion,
     cliSrcHash: $cliSrcHash,
+    cliOpamPinOverrides: $cliOpamPinOverrides,
     cliPnpmDepsHash: $cliPnpmDepsHash,
     cliBundlePnpmDepsHash: $cliBundlePnpmDepsHash,
     cliCljDepsHash: $cliCljDepsHash,


### PR DESCRIPTION
## Problem

The nightly `publish-release` "Validate flake" step fails with
`[opam-nix] a git dependency without an explicit sha1 is not supported in pure evaluation mode`
([failing run](https://github.com/Bad3r/nix-logseq-git-flake/actions/runs/28216831264/job/83590619224)).

Upstream `logseq/logseq@3684727952e6` (2026-06-25 "chore: update opam") repointed
`cli/logseq-cli.opam` pin-depends for `melange-edn`, `melange-transit`, and `humanize` at
the mutable `#main` branch. opam-nix's `fetchGitURL` rejects a git fragment that is not a
40-char sha1 in pure evaluation mode, so `nix flake check` throws. The desktop build legs
use native opam (which accepts branch refs) and pass, so every `build` leg is green while
only the Nix validation breaks. It does not self-heal: upstream's later `eda573c` re-pinned
only `melange-transit`, leaving the other two on `#main`.

## Fix

`opam-deps.nix` resolves the closure over the unpatched upstream `src` FOD, so the
`patches/` mechanism cannot reach it. Resolution moves to the producer and rides through
the manifest, like the other CLI hashes:

- `scripts/update-nightly.sh` (Phase 3b) reads the opam at `LOGSEQ_REV`, `git ls-remote`s
  each non-sha1 git pin to its current commit, and writes `cliOpamPinOverrides`
  (`{from,to}` URL pairs) into the manifest.
- `lib/loadManifest.nix` requires the field and asserts each `to` ends in an explicit
  40-char sha1.
- `opam-deps.nix` applies the rewrites with `substituteInPlace --replace-fail` before
  `buildOpamProject` reads the file; an empty list reads `src/cli` in place (no-op).

Resolving at manifest time keeps the pin tracking upstream every nightly instead of
freezing a literal. The `melange-edn` `main` HEAD moved twice within ~30 minutes on
2026-06-26 (`bdc79c1d` -> `f155433f`), so a hardcoded pin would already diverge from what
the desktop legs build.

## Validation

- nixfmt, shfmt, shellcheck, deadnix, statix: clean.
- `nix eval` of `.#packages.x86_64-linux.logseq-cli.drvPath` and
  `.#packages.x86_64-linux.logseq.drvPath`: identical drvs at the current empty-override
  rev (no regression).
- Producer resolution and the `substituteInPlace` rewrite verified end-to-end against the
  real upstream opam at the failing-era rev (`3684727952e6`) and current master: fully
  sha1-pinned, zero `#main` remaining, `--replace-fail` matched every `from`.
