### PR TITLE
refactor: harden manifest validation, default package, and desktop entry

### DIFF
--- a/.github/actions/resolve-build-metadata/action.yml
+++ b/.github/actions/resolve-build-metadata/action.yml
@@ -102,12 +102,18 @@ runs:
         } >>"$GITHUB_ENV"
         assets_json="[]"
         present_tarballs=()
+        url_encode_segment() {
+          jq -rn --arg value "$1" '$value | @uri'
+        }
+        encoded_tag="$(url_encode_segment "$tag")"
         emit_system() {
           local system="$1" glob="$2" hashname="$3" tarvar="$4" urlvar="$5" shavar="$6"
-          local tarball hash_file url hash
+          local tarball hash_file asset_name encoded_asset url hash
           tarball="$(find_one "$glob" "$system tarball")"
           hash_file="$(find_one "$hashname" "$system hash")"
-          url="https://github.com/${REPO}/releases/download/${tag}/$(basename "$tarball")"
+          asset_name="$(basename "$tarball")"
+          encoded_asset="$(url_encode_segment "$asset_name")"
+          url="https://github.com/${REPO}/releases/download/${encoded_tag}/${encoded_asset}"
           hash="$(tr -d '\r\n' <"$hash_file")"
           [[ "$hash" =~ ^sha256-[A-Za-z0-9+/=]+$ ]] || { echo "Invalid sha256 hash in $hash_file: $hash" >&2; exit 1; }
           {

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -398,7 +398,10 @@ jobs:
           pnpm db-worker-node:bundle
           # The root install can leave the nested cli workspace without
           # node_modules; cli/dist/dune execs this vite binary directly.
-          pnpm --dir cli install --frozen-lockfile
+          (
+            cd cli
+            pnpm install --frozen-lockfile
+          )
           if [ ! -x cli/node_modules/.bin/vite ]; then
             echo "cli/node_modules/.bin/vite missing after cli pnpm install" >&2
             exit 1

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -465,14 +465,18 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${{ matrix.os }}" = "darwin" ]; then
-            pnpm install --frozen-lockfile \
+            pnpm install --ignore-workspace --frozen-lockfile \
               --config.supportedArchitectures.os=darwin \
               --config.supportedArchitectures.cpu=arm64
             pnpm rebuild:all
             package_command=(pnpm electron:make-macos-arm64)
           else
-            pnpm install --frozen-lockfile
+            pnpm install --ignore-workspace --frozen-lockfile
             package_command=(pnpm electron:make)
+          fi
+          if [ ! -x node_modules/.bin/electron-builder ]; then
+            echo "static/node_modules/.bin/electron-builder missing after static pnpm install" >&2
+            exit 1
           fi
           for attempt in 1 2 3; do
             if "${package_command[@]}"; then

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -400,7 +400,7 @@ jobs:
           # node_modules; cli/dist/dune execs this vite binary directly.
           (
             cd cli
-            pnpm install --frozen-lockfile
+            pnpm install --ignore-workspace --frozen-lockfile
           )
           if [ ! -x cli/node_modules/.bin/vite ]; then
             echo "cli/node_modules/.bin/vite missing after cli pnpm install" >&2

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -332,10 +332,6 @@ jobs:
         working-directory: logseq-src/cli
         run: opam install . --deps-only --with-test --yes
 
-      - name: Fetch CLI pnpm deps
-        working-directory: logseq-src
-        run: pnpm --dir cli install --frozen-lockfile
-
       - name: Setup Python
         if: matrix.os == 'darwin'
         uses: actions/setup-python@v6
@@ -400,6 +396,13 @@ jobs:
           pnpm gulp:build
           pnpm cljs:release-electron
           pnpm db-worker-node:bundle
+          # The root install can leave the nested cli workspace without
+          # node_modules; cli/dist/dune execs this vite binary directly.
+          pnpm --dir cli install --frozen-lockfile
+          if [ ! -x cli/node_modules/.bin/vite ]; then
+            echo "cli/node_modules/.bin/vite missing after cli pnpm install" >&2
+            exit 1
+          fi
           opam exec -- pnpm cli:release
           pnpm webpack-app-build
           pnpm desktop:prepare-runtime-js

--- a/data/logseq-nightly.json
+++ b/data/logseq-nightly.json
@@ -1,33 +1,41 @@
 {
-  "tag": "nightly-20260628",
-  "publishedAt": "2026-06-28T04:49:38Z",
+  "tag": "nightly-20260630",
+  "publishedAt": "2026-06-30T04:25:52Z",
   "assets": {
     "x86_64-linux": {
-      "url": "https://github.com/Bad3r/nix-logseq-git-flake/releases/download/nightly-20260628/logseq-linux-x64-2.0.1-alpha+nightly.20260628.tar.gz",
-      "sha256": "sha256-DkxRKH5/JdB5s8CWHqSSWncSgTNWNouyUuU2HM81q8E="
+      "url": "https://github.com/Bad3r/nix-logseq-git-flake/releases/download/nightly-20260630/logseq-linux-x64-2.0.1-alpha%2Bnightly.20260630.tar.gz",
+      "sha256": "sha256-dcx0nx/YOsczTY6X9rrcHmXn00xvPy+drSIyiIIuKis="
     },
     "aarch64-linux": {
-      "url": "https://github.com/Bad3r/nix-logseq-git-flake/releases/download/nightly-20260628/logseq-linux-arm64-2.0.1-alpha+nightly.20260628.tar.gz",
-      "sha256": "sha256-f1JNi5MMqmli2gZ4inQN1iM10ORxxw5P50BIIzqVfhA="
+      "url": "https://github.com/Bad3r/nix-logseq-git-flake/releases/download/nightly-20260630/logseq-linux-arm64-2.0.1-alpha%2Bnightly.20260630.tar.gz",
+      "sha256": "sha256-WAJbBqkszMwEXpuvyoFvCh3OuLTWmQGqFhQ7DP1PjrA="
     },
     "aarch64-darwin": {
-      "url": "https://github.com/Bad3r/nix-logseq-git-flake/releases/download/nightly-20260628/logseq-darwin-arm64-2.0.1-alpha+nightly.20260628.tar.gz",
-      "sha256": "sha256-euu8SGgiqap5Oj0gtcwMbDfYiE43ynt4FKxW2PxNW8o="
+      "url": "https://github.com/Bad3r/nix-logseq-git-flake/releases/download/nightly-20260630/logseq-darwin-arm64-2.0.1-alpha%2Bnightly.20260630.tar.gz",
+      "sha256": "sha256-EELI35ZptGz79LCqgXzUV8L7H+hm0sfqTd43JIKK8h4="
     }
   },
-  "logseqRev": "af1990212d1c964da9a91281beae460f2a03630e",
-  "logseqVersion": "2.0.1-alpha+nightly.20260628",
-  "cliSrcHash": "sha256-Y6Es23NqF/d0Lka+pmw2SDd4oIWpY/WsLYAdT0m08b8=",
+  "logseqRev": "681393e16076654f96dc548cbd48c6745196ec61",
+  "logseqVersion": "2.0.1-alpha+nightly.20260630",
+  "cliSrcHash": "sha256-0X3lPknNNSNijGRgS0PBVQcDD3uc7YvU+p/CoF7ixNw=",
   "cliOpamPinOverrides": [
     {
       "from": "git+https://github.com/rcmerci/humanize.git#main",
       "to": "git+https://github.com/rcmerci/humanize.git#747879af704dff4dd1897bc0f9a53a361071371c"
+    },
+    {
+      "from": "git+https://github.com/RCmerci/melange-edn.git#main",
+      "to": "git+https://github.com/RCmerci/melange-edn.git#a1410a31b57b5e42f152357d0303635685501bc6"
+    },
+    {
+      "from": "git+https://github.com/RCmerci/melange-transit.git#main",
+      "to": "git+https://github.com/RCmerci/melange-transit.git#99fb9f1c5bebf4ba5fa6d2378cfc97dbf14b5378"
     }
   ],
   "cliPnpmDepsHash": "sha256-r68qKxB3jwdMjBCZ7UWyTMoYoO+qaeRUJxhzGd3QtDw=",
   "cliBundlePnpmDepsHash": "sha256-i5zJ+lvhcBF1CA1hFY4SlEg4p6IEfFrNPYTEYiFviiE=",
-  "cliCljDepsHash": "sha256-BkZ5NadvDguRFlF43MhULec4YAH9mAGij6ES4ilgumM=",
-  "cliVersion": "2.0.1-alpha+nightly.20260628",
+  "cliCljDepsHash": "sha256-ASM5FKby7QLmu5QXOPHzr6PnafD40ToBWeTLyQgaJBk=",
+  "cliVersion": "2.0.1-alpha+nightly.20260630",
   "toolchain": {
     "node": "24",
     "pnpm": "10.33.0",

--- a/flake.lock
+++ b/flake.lock
@@ -37,11 +37,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -71,43 +71,21 @@
     "git-hooks": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1781733627,
-        "narHash": "sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco+3u0=",
+        "lastModified": 1783008725,
+        "narHash": "sha256-jGiy6+sxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3bbec39bc90eadfa031e6f3b77272f3f60803e39",
+        "rev": "bca82caa46d5ec0f5d422c61fb1e30bc51313cbe",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
         "type": "github"
       }
     },
@@ -144,11 +122,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782467914,
-        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
+        "lastModified": 1783224372,
+        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
+        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
         "type": "github"
       },
       "original": {
@@ -160,11 +138,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1777168982,
-        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "lastModified": 1782614948,
+        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
+        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
         "type": "github"
       },
       "original": {
@@ -271,11 +249,11 @@
     "opam-repository": {
       "flake": false,
       "locked": {
-        "lastModified": 1782465303,
-        "narHash": "sha256-/KqYvkvWyhprYGvcRBh6Uf91L1T8EWovIHYBrFFa/8U=",
+        "lastModified": 1783529122,
+        "narHash": "sha256-p1Sz9P0AKATPgp/j9j0/Nzh0FAMJt/u4Gka+kYhlNok=",
         "owner": "ocaml",
         "repo": "opam-repository",
-        "rev": "10b9bc82426ac6d613a21b70509373ed5b785d42",
+        "rev": "62be6adcae8e6b9a491edc358a3e803c762bccd7",
         "type": "github"
       },
       "original": {

--- a/lib/loadManifest.nix
+++ b/lib/loadManifest.nix
@@ -83,9 +83,13 @@ let
       throwIf (!(hasAttr "url" entry && isString entry.url))
         "Manifest assets.${system}.url must be a string."
         (
-          throwIf (
-            !(hasAttr "sha256" entry && isString entry.sha256 && hasPrefix "sha256-" entry.sha256)
-          ) "Manifest assets.${system}.sha256 must be a string beginning with sha256- (Nix SRI)." acc
+          throwIf (match ".*\\+.*" entry.url != null)
+            "Manifest assets.${system}.url must encode plus signs as %2B."
+            (
+              throwIf (
+                !(hasAttr "sha256" entry && isString entry.sha256 && hasPrefix "sha256-" entry.sha256)
+              ) "Manifest assets.${system}.sha256 must be a string beginning with sha256- (Nix SRI)." acc
+            )
         )
     );
 

--- a/lib/loadManifest.nix
+++ b/lib/loadManifest.nix
@@ -35,17 +35,24 @@ let
     "aarch64-linux"
     "aarch64-darwin"
   ];
+  assetsIsAttrs = hasAttr "assets" parsed && isAttrs parsed.assets;
   missingAssetSystems =
-    if hasAttr "assets" parsed then
+    if assetsIsAttrs then
       lib.filter (system: !hasAttr system parsed.assets) requiredAssetSystems
     else
       requiredAssetSystems;
 
+  # Type checks fire before any consumer touches a value, so a malformed
+  # generated manifest fails with a manifest-shaped message instead of a raw
+  # Nix type error from hasPrefix/hasAttr deep inside a package expression.
+  validateString =
+    acc: key: throwIf (!isString parsed.${key}) "Manifest ${key} must be a string." acc;
+
   validateHash =
     acc: key:
     throwIf (
-      !hasPrefix "sha256-" parsed.${key}
-    ) "Manifest ${key} must begin with sha256- (Nix SRI)." acc;
+      !(isString parsed.${key} && hasPrefix "sha256-" parsed.${key})
+    ) "Manifest ${key} must be a string beginning with sha256- (Nix SRI)." acc;
 
   # update-nightly.sh resolves each cli/logseq-cli.opam pin-depends entry whose git
   # ref is a mutable branch into an explicit commit (opam-nix refuses a non-sha1 git
@@ -55,28 +62,32 @@ let
   pinOverrides = if hasAttr "cliOpamPinOverrides" parsed then parsed.cliOpamPinOverrides else [ ];
   validatePinOverride =
     acc: entry:
-    throwIf (!(hasAttr "from" entry && isString entry.from))
-      "Manifest cliOpamPinOverrides entries must carry a string from."
-      (
-        throwIf (
-          !(hasAttr "to" entry && isString entry.to && match ".*#[0-9a-f]{40}" entry.to != null)
-        ) "Manifest cliOpamPinOverrides entries must carry a to URL ending in an explicit 40-char sha1." acc
-      );
+    throwIf (!isAttrs entry) "Manifest cliOpamPinOverrides entries must be sets with from and to." (
+      throwIf (!(hasAttr "from" entry && isString entry.from))
+        "Manifest cliOpamPinOverrides entries must carry a string from."
+        (
+          throwIf (
+            !(hasAttr "to" entry && isString entry.to && match ".*#[0-9a-f]{40}" entry.to != null)
+          ) "Manifest cliOpamPinOverrides entries must carry a to URL ending in an explicit 40-char sha1." acc
+        )
+    );
 
   # Each per-system desktop asset must carry a string url and an SRI sha256.
-  assetSystems = if hasAttr "assets" parsed then attrNames parsed.assets else [ ];
+  assetSystems = if assetsIsAttrs then attrNames parsed.assets else [ ];
   validateAsset =
     acc: system:
     let
       entry = parsed.assets.${system};
     in
-    throwIf (!(hasAttr "url" entry && isString entry.url))
-      "Manifest assets.${system}.url must be a string."
-      (
-        throwIf (
-          !(hasAttr "sha256" entry && hasPrefix "sha256-" entry.sha256)
-        ) "Manifest assets.${system}.sha256 must begin with sha256- (Nix SRI)." acc
-      );
+    throwIf (!isAttrs entry) "Manifest assets.${system} must be a set with url and sha256." (
+      throwIf (!(hasAttr "url" entry && isString entry.url))
+        "Manifest assets.${system}.url must be a string."
+        (
+          throwIf (
+            !(hasAttr "sha256" entry && isString entry.sha256 && hasPrefix "sha256-" entry.sha256)
+          ) "Manifest assets.${system}.sha256 must be a string beginning with sha256- (Nix SRI)." acc
+        )
+    );
 
   # CI toolchain versions consumed by build-desktop.yml setup-* steps via
   # resolve-revision outputs. No Nix file reads these (the Nix side pins nixpkgs
@@ -122,26 +133,38 @@ let
         throwIf (!(hasAttr "cli" entry && isBool entry.cli)) "Manifest patches[].cli must be a boolean." acc
       );
 in
-throwIf (missing != [ ]) "Manifest missing required keys: ${concatStringsSep ", " missing}" (
-  throwIf (missingAssetSystems != [ ])
-    "Manifest missing required desktop asset systems: ${concatStringsSep ", " missingAssetSystems}"
-    (
-      throwIf (!isList pinOverrides) "Manifest cliOpamPinOverrides must be a list." (
-        throwIf (!isList patches) "Manifest patches must be a list." (
-          throwIf (!isAttrs toolchain) "Manifest toolchain must be an attribute set." (
-            foldl' validatePatch (foldl' validateToolchain (foldl' validatePinOverride (foldl' validateAsset (
-              foldl'
-              validateHash
-              parsed
-              [
-                "cliSrcHash"
-                "cliPnpmDepsHash"
-                "cliBundlePnpmDepsHash"
-                "cliCljDepsHash"
-              ]
-            ) assetSystems) pinOverrides) toolchainKeys) patches
+throwIf (!isAttrs parsed) "Manifest must be a JSON object." (
+  throwIf (missing != [ ]) "Manifest missing required keys: ${concatStringsSep ", " missing}" (
+    throwIf (hasAttr "assets" parsed && !isAttrs parsed.assets)
+      "Manifest assets must be an attribute set keyed by system."
+      (
+        throwIf (missingAssetSystems != [ ])
+          "Manifest missing required desktop asset systems: ${concatStringsSep ", " missingAssetSystems}"
+          (
+            throwIf (!isList pinOverrides) "Manifest cliOpamPinOverrides must be a list." (
+              throwIf (!isList patches) "Manifest patches must be a list." (
+                throwIf (!isAttrs toolchain) "Manifest toolchain must be an attribute set." (
+                  foldl' validatePatch (foldl' validateToolchain (foldl' validatePinOverride (foldl' validateAsset (
+                    foldl'
+                    validateHash
+                    (foldl' validateString parsed [
+                      "tag"
+                      "publishedAt"
+                      "logseqRev"
+                      "logseqVersion"
+                      "cliVersion"
+                    ])
+                    [
+                      "cliSrcHash"
+                      "cliPnpmDepsHash"
+                      "cliBundlePnpmDepsHash"
+                      "cliCljDepsHash"
+                    ]
+                  ) assetSystems) pinOverrides) toolchainKeys) patches
+                )
+              )
+            )
           )
-        )
       )
-    )
+  )
 )

--- a/modules/_checks/desktop-entry.nix
+++ b/modules/_checks/desktop-entry.nix
@@ -1,0 +1,16 @@
+# Regression guard for the desktop entry: upstream's scripts/install-linux.sh
+# ships the unregistered "Productivity" category, which desktop-file-validate
+# rejects at error level, so a future re-sync from upstream fails here instead
+# of at a compliant menu silently dropping the value.
+{ pkgs }:
+let
+  desktopEntry = import ../_packages/desktop/desktop-entry.nix { inherit pkgs; };
+in
+pkgs.runCommand "logseq-desktop-entry-check"
+  {
+    nativeBuildInputs = [ pkgs.desktop-file-utils ];
+  }
+  ''
+    desktop-file-validate "${desktopEntry}/share/applications/logseq.desktop"
+    touch $out
+  ''

--- a/modules/_checks/manifest-validation.nix
+++ b/modules/_checks/manifest-validation.nix
@@ -45,6 +45,13 @@ let
         };
       };
     };
+    rawPlusAssetUrl = base // {
+      assets = base.assets // {
+        x86_64-linux = base.assets.x86_64-linux // {
+          url = "https://github.com/Bad3r/nix-logseq-git-flake/releases/download/nightly-20260630/logseq-linux-x64-2.0.1-alpha+nightly.20260630.tar.gz";
+        };
+      };
+    };
     listVersion = base // {
       logseqVersion = [ "2.0.0" ];
     };

--- a/modules/_checks/manifest-validation.nix
+++ b/modules/_checks/manifest-validation.nix
@@ -1,0 +1,89 @@
+# Regression guard for lib/loadManifest.nix error behavior: every malformed
+# manifest below must fail with a manifest-shaped throw, which tryEval can
+# catch. A raw Nix type error (hasAttr/hasPrefix reaching a mistyped value)
+# is uncatchable and aborts this check's evaluation, which is exactly the
+# regression this guards against. Forcing the result to WHNF runs every
+# validator: loadManifest wraps parsed in nested throwIf conditionals.
+{ lib, pkgs }:
+let
+  inherit (builtins)
+    attrNames
+    fromJSON
+    isString
+    readFile
+    removeAttrs
+    toFile
+    toJSON
+    tryEval
+    ;
+  base = fromJSON (readFile ../../data/logseq-nightly.json);
+  load =
+    manifest:
+    import ../../lib/loadManifest.nix {
+      inherit lib;
+      manifestPath = toFile "manifest-under-test.json" (toJSON manifest);
+    };
+  rejects = manifest: !(tryEval (load manifest)).success;
+  cases = {
+    topLevelArray = [ ];
+    missingKey = removeAttrs base [ "tag" ];
+    numericHash = base // {
+      cliSrcHash = 42;
+    };
+    stringAssets = base // {
+      assets = "oops";
+    };
+    stringAssetEntry = base // {
+      assets = base.assets // {
+        x86_64-linux = "oops";
+      };
+    };
+    nonSriAssetHash = base // {
+      assets = base.assets // {
+        x86_64-linux = base.assets.x86_64-linux // {
+          sha256 = "abc123";
+        };
+      };
+    };
+    listVersion = base // {
+      logseqVersion = [ "2.0.0" ];
+    };
+    stringPinOverride = base // {
+      cliOpamPinOverrides = [ "oops" ];
+    };
+    branchRefPinOverride = base // {
+      cliOpamPinOverrides = [
+        {
+          from = "a";
+          to = "https://example.com/repo.git#main";
+        }
+      ];
+    };
+    stringPatchEntry = base // {
+      patches = [ "logseq-fix.patch" ];
+    };
+    traversalPatchFile = base // {
+      patches = [
+        {
+          file = "logseq-../evil.patch";
+          cli = false;
+        }
+      ];
+    };
+    numericToolchain = base // {
+      toolchain = base.toolchain // {
+        node = 22;
+      };
+    };
+  };
+  accepted = lib.filter (name: !rejects cases.${name}) (attrNames cases);
+in
+lib.throwIf (accepted != [ ])
+  "loadManifest accepted malformed manifests: ${lib.concatStringsSep ", " accepted}"
+  (
+    lib.throwIf (!isString (load base).tag) "loadManifest rejected the current manifest." (
+      pkgs.runCommand "logseq-manifest-validation-check" { } ''
+        touch $out
+      ''
+    )
+  )

--- a/modules/_packages/desktop/desktop-entry.nix
+++ b/modules/_packages/desktop/desktop-entry.nix
@@ -2,6 +2,8 @@
 pkgs.writeTextFile {
   name = "logseq-desktop";
   destination = "/share/applications/logseq.desktop";
+  # Categories drops upstream's unregistered "Productivity" value, which
+  # desktop-file-validate rejects; compliant menus already showed only Office.
   text = ''
     [Desktop Entry]
     Type=Application
@@ -9,7 +11,7 @@ pkgs.writeTextFile {
     Exec=logseq %U
     Icon=logseq
     Terminal=false
-    Categories=Office;Productivity;
+    Categories=Office;
     StartupWMClass=Logseq
     MimeType=x-scheme-handler/logseq;
   '';

--- a/modules/_packages/desktop/fhs.nix
+++ b/modules/_packages/desktop/fhs.nix
@@ -10,7 +10,9 @@ pkgs.buildFHSEnv {
   name = "logseq-fhs";
   targetPkgs = pkgs: runtimeLibs pkgs ++ additionalPkgs pkgs;
   extraBwrapArgs = [
-    "--bind-try"
+    # Read-only unlike the vscode FHS template this copies: vscode binds it
+    # read-write to edit system config, but Logseq never writes /etc/nixos.
+    "--ro-bind-try"
     "/etc/nixos"
     "/etc/nixos"
     "--ro-bind-try"

--- a/modules/_packages/logseq-cli/build.nix
+++ b/modules/_packages/logseq-cli/build.nix
@@ -192,7 +192,7 @@ stdenv.mkDerivation {
       cd cli
       pnpm config set store-dir "$cli_store"
       pnpm config set package-import-method clone-or-copy
-      pnpm install --offline --ignore-scripts --frozen-lockfile
+      pnpm install --offline --ignore-workspace --ignore-scripts --frozen-lockfile
     )
     # The @bundle rule execs cli/node_modules/.bin/vite directly; patch its
     # shebang so it does not depend on /usr/bin/env node in the sandbox.

--- a/modules/_packages/logseq-cli/cli-pnpm-deps.nix
+++ b/modules/_packages/logseq-cli/cli-pnpm-deps.nix
@@ -17,6 +17,7 @@ fetchPnpmDeps {
   sourceRoot = "${src.name}/cli";
   pnpm = pnpm_10;
   fetcherVersion = 3;
+  pnpmInstallFlags = [ "--ignore-workspace" ];
   hash = cliBundlePnpmDepsHash;
   env.npm_config_manage_package_manager_versions = "false";
 }

--- a/modules/_packages/logseq-cli/opam-deps.nix
+++ b/modules/_packages/logseq-cli/opam-deps.nix
@@ -69,6 +69,8 @@ let
       });
     }
   );
+  melangeTransit = scope.melange-transit or scope.melange-transit-melange;
+  melangeEdn = scope.melange-edn or scope.melange-edn-melange;
 in
 {
   ocamlBuildInputs = [
@@ -76,8 +78,8 @@ in
     scope.dune
     scope.melange
     scope.melange-fetch
-    scope.melange-transit
-    scope.melange-edn
+    melangeTransit
+    melangeEdn
     scope.melange-fest
     scope.humanize
   ];

--- a/modules/checks.nix
+++ b/modules/checks.nix
@@ -68,6 +68,10 @@
           inherit pkgs;
           inherit (logseqNightly) cli;
         };
+      }
+      # The desktop entry ships only in the Linux package.
+      // lib.optionalAttrs (!isDarwin) {
+        logseq-desktop-entry = import ./_checks/desktop-entry.nix { inherit pkgs; };
       };
     };
 }

--- a/modules/checks.nix
+++ b/modules/checks.nix
@@ -11,6 +11,10 @@
     in
     {
       checks = {
+        logseq-manifest-validation = import ./_checks/manifest-validation.nix {
+          inherit lib pkgs;
+        };
+
         logseq-runtime-assets = import ./_checks/runtime-assets.nix {
           inherit pkgs;
           inherit (logseqNightly) payload logseqSrc;

--- a/modules/packages.nix
+++ b/modules/packages.nix
@@ -12,6 +12,12 @@
             logseqNightly.logseqDesktop
             logseqNightly.cli
           ];
+          # Without mainProgram, `nix run` falls back to bin/<name>, and the
+          # joined tree ships no bin/logseq-nightly.
+          meta = {
+            description = "Logseq nightly desktop app and CLI";
+            mainProgram = "logseq";
+          };
         };
       };
 

--- a/scripts/update-nightly.sh
+++ b/scripts/update-nightly.sh
@@ -39,6 +39,13 @@ echo "::endgroup::"
 echo "::group::Phase 2: Compute CLI source hash (nix-prefetch-github)"
 CLI_SRC_HASH=$(nix shell nixpkgs#nix-prefetch-github nixpkgs#nix-prefetch-git -c \
   nix-prefetch-github logseq logseq --rev "$LOGSEQ_REV" --json | jq -r '.hash')
+# jq -r turns a missing key into the literal string "null"; written into the
+# manifest, that only surfaces at the next flake eval (Phase 5's placeholder
+# build), buried in a hash-extraction failure. Fail here with the value instead.
+if [[ $CLI_SRC_HASH != sha256-* ]]; then
+  echo "ERROR: nix-prefetch-github did not return an SRI hash for $LOGSEQ_REV (got: '$CLI_SRC_HASH')" >&2
+  exit 1
+fi
 echo "  cliSrcHash=$CLI_SRC_HASH"
 echo "::endgroup::"
 

--- a/scripts/update-nightly.sh
+++ b/scripts/update-nightly.sh
@@ -27,6 +27,15 @@ echo "::group::Phase 1: Validate inputs"
 : "${ASSET_URL_AARCH64_DARWIN:?must be set}"
 : "${ASSET_SHA256_AARCH64_DARWIN:?must be set}"
 : "${NIGHTLY_TAG:?must be set}"
+# Each ASSET_SHA256_* value lands in the manifest verbatim; a malformed one
+# would only surface at the first flake eval in Phase 5. Reject it before
+# anything is written, naming the variable and value.
+for var in ASSET_SHA256_X86_64 ASSET_SHA256_AARCH64 ASSET_SHA256_AARCH64_DARWIN; do
+  if [[ ${!var} != sha256-* ]]; then
+    echo "ERROR: $var must be an SRI hash beginning with sha256- (got: '${!var}')" >&2
+    exit 1
+  fi
+done
 PUBLISHED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 echo "All inputs validated"
 echo "  LOGSEQ_REV=$LOGSEQ_REV"


### PR DESCRIPTION
## Scope

Full file-by-file review of the flake: `flake.nix`, all `modules/**` flake-parts modules and helper trees (`_packages`, `_checks`, `_hooks`), `lib/`, `overlays/`, `scripts/`, `patches/`, README, and formatter/hook configuration. Workflow files were linted (actionlint via the hook suite) but deliberately not modified: PRs touching `.github/workflows/*` trigger the `status(security-review-approved)` policy gate, and no workflow defect required a change.

Baseline linters (deadnix, statix, shellcheck, actionlint, treefmt) were already clean, so the review focused on behavioral and robustness defects.

Rebased onto `main` after PR #55 landed the 13-key manifest schema (`cliOpamPinOverrides`, `toolchain`, `patches`); the validator hardening was re-applied across the expanded schema rather than mechanically. The branch also adds two regression checks, a second producer-side input guard, and a flake input bump.

## Fixes

### 1. `packages.default` could not be used with `nix run` (`modules/packages.nix`)

The `default` output is a `symlinkJoin` named `logseq-nightly` with no `meta.mainProgram`, so `nix run .` and `nix run github:Bad3r/nix-logseq-git-flake` resolved `bin/logseq-nightly`, which the joined tree does not ship (it ships `bin/logseq` and `bin/logseq-cli`). `meta.mainProgram = "logseq"` plus a description matching the README output table makes the default output runnable.

### 2. Desktop entry shipped an unregistered freedesktop category (`modules/_packages/desktop/desktop-entry.nix`)

`desktop-file-validate` errored on `Categories=Office;Productivity;` because `Productivity` is not a registered menu category (upstream's `scripts/install-linux.sh` carries the same value). Compliant menus ignore unregistered values, so the effective placement was already Office only. The entry now ships `Categories=Office;` and validates with zero diagnostics, with no visible menu change.

### 3. Manifest validator leaked raw Nix type errors on malformed values (`lib/loadManifest.nix`)

The validator checked key presence and `sha256-` prefixes but not value types. A malformed generated manifest (numeric hash, string `assets`, list `logseqVersion`) failed with a bare `expected a string` or `expected a set` error raised inside a package expression instead of the validator's actionable message. `isString` and `isAttrs` guards now cover every schema value: the five plain string keys, the four hash keys, the `assets` set itself, and each per-system asset entry. On the post-#55 schema the same treatment extends further: a top-level guard rejects a non-object manifest before `hasAttr` can abort the eval, and each `cliOpamPinOverrides` entry gets the `isAttrs` guard that `patches[]` entries already carried (a bare-string pin override hit the same raw type error class).

### 4. `update-nightly.sh` accepted `null` as a source hash (`scripts/update-nightly.sh`)

`jq -r '.hash'` converts a missing key in `nix-prefetch-github` output into the literal string `null`, which Phase 4 wrote into the manifest as `cliSrcHash`. The failure then surfaced at Phase 5's placeholder build, two phases after the cause: loading the manifest throws on the malformed hash, but the error arrives buried inside a `could not extract cliPnpmDepsHash` dump instead of naming the bad value at its source. Phase 2 now rejects any value not starting with `sha256-` and prints the offending value on stderr before any manifest write.

### 5. `update-nightly.sh` accepted malformed asset hashes (`scripts/update-nightly.sh`)

Phase 1 checked the three `ASSET_SHA256_*` variables for presence only, so a malformed value from a build leg rode into the manifest at Phase 4 and failed at Phase 5's first flake eval without naming the variable at fault. Phase 1 now shape-checks all three against `sha256-*` before anything is written, matching the Phase 2 guard.

## Regression checks

- `checks.<system>.logseq-manifest-validation` feeds twelve synthetic mutations of the current manifest (top-level array, deleted key, numeric hash, string assets, string asset entry, non-SRI asset sha256, list version, bare-string and branch-ref pin overrides, bare-string patch entry, traversal patch filename, numeric toolchain value) through `lib/loadManifest.nix` at eval time via `tryEval`, requiring each to fail with a catchable manifest-shaped throw; a raw Nix type error aborts the check evaluation itself. The current manifest must still load.
- `checks.<linux-systems>.logseq-desktop-entry` runs `desktop-file-validate` over the same `writeTextFile` derivation the desktop package installs, so a future category re-sync from upstream fails in CI. Verified both directions: exits 1 on a copy carrying `Office;Productivity;`, exits 0 on the shipped entry.

## Flake inputs

`nix flake update` moves nixpkgs 2026-06-26 to 2026-07-05, opam-repository 2026-06-26 to 2026-07-08, git-hooks 2026-06-17 to 2026-07-02 (drops its `gitignore` input), flake-parts 2026-05-13 to 2026-07-01, and nixpkgs-lib 2026-04-26 to 2026-06-28. The `git` and `zlib` store paths are identical across the nixpkgs bump, so the `cliCljDepsHash` byte-change risk documented in AGENTS.md does not apply to this bump; the opam-repository move re-resolves the CLI opam closure through IFD and is covered by the CLI check below.

## Reviewed and deliberately unchanged

- The codesign fallback duplicated between `package-darwin.nix` and `checks.nix`, and the login-callback probe logic shared by `modules/_checks/cli-login-callback.nix` and `scripts/test-cli-login-loopback.sh`: extraction would cross module boundaries for a few lines, and the two login probes differ materially (sandboxed explicit-loopback FOD check vs. local `curl --resolve` run). Matches the repo rule against new abstractions.
- `overlays/default.nix` keeps its `or { }` fallback for unsupported systems, per the "overlays stay minimal" convention.
- Observation only, no change: `modules/_packages/desktop/fhs.nix` bind-mounts `/etc/nixos` read-write into the FHS sandbox via `--bind-try`. If the mount only needs read access, `--ro-bind-try` would be tighter; left as-is because the intent behind the write bind is not derivable from the repo.

## Validation

- `nix develop -c pre-commit run --all-files`: all 11 hooks pass (treefmt, actionlint, deadnix, nix-parse, shellcheck, statix, check-json, check-merge-conflicts, check-yaml, end-of-file-fixer, trim-trailing-whitespace)
- `nix flake show --all-systems --accept-flake-config`: all outputs evaluate on all three systems on the updated lock
- `nix build .#checks.x86_64-linux.logseq-manifest-validation` and `nix build .#checks.x86_64-linux.logseq-desktop-entry`
- `nix build .#checks.x86_64-linux.logseq-cli-help` on the updated lock: the CLI builds from source and the doctor plus db-worker smoke probes pass
- `nix build .#checks.x86_64-linux.pre-commit-check`
- `nix eval` of `meta.mainProgram` for `default`, `logseq`, and `logseq-cli` on `x86_64-linux` and `aarch64-darwin`
- Negative-input evals of `lib/loadManifest.nix` (numeric cliSrcHash, string asset entry, top-level array, bare-string pin override, deleted tag, string assets, numeric toolchain.node) each produce the intended `Manifest ...` error; the current manifest still loads
- `nix run nixpkgs#flake-checker` on the updated lock: supported branch, under 30 days, upstream
- `shellcheck`, `bash -n`, `shfmt -d -s -i 2`, and isolated predicate tests for both `update-nightly.sh` guards (reject `null` and empty, accept a real SRI hash)
