### PR TITLE
fix(flake): pin package nixpkgs so consumer overrides keep cache hits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ The manifest is the single source of truth for downstream consumers. Adding a fi
 
 ### Manifest fan-out inside flake modules
 
-- `modules/logseq-scope.nix` loads `data/logseq-nightly.json` through `lib/loadManifest.nix` and exposes the shared package set as a per-system module argument.
+- `modules/logseq-scope.nix` loads `data/logseq-nightly.json` through `lib/loadManifest.nix` and exposes the shared package set as a per-system module argument. It builds that set from `pkgsPinned` (`nixpkgs-pinned.legacyPackages.<system>`), a nixpkgs input kept separate from the flake's overridable `nixpkgs`; `opam-nix` follows `nixpkgs-pinned` too. Consumers do not override `nixpkgs-pinned`, so the nixpkgs-dependent opam-nix/Melange closure stays on the rev CI built and pushed to Cachix even when a consumer sets `inputs.<this>.inputs.nixpkgs.follows` for dedup. Overriding `nixpkgs` used to re-hash that closure and force a multi-hour local opam-nix `resolve`. Do not point package builds back at the overridable `pkgs` (that reintroduces the cache miss); `pkgs` stays for the dev shell, formatter, and check runners only.
 - `modules/_packages/desktop/payload.nix` selects the per-system desktop bundle from `manifest.assets.<system>` (`url` + `sha256`), keyed by `pkgs.stdenv.hostPlatform.system`, and throws on an unsupported system.
 - `modules/_packages/desktop/tree.nix` branches by OS. Linux expects the flat Electron payload with an executable `logseq`; Darwin expects exactly one top-level `*.app` bundle containing `Contents/MacOS/Logseq` and `Contents/Resources/app.asar`.
 - `modules/_packages/desktop/upstream-source.nix` fetches `logseq/logseq` at `manifest.logseqRev` with `manifest.cliSrcHash`; this source is shared by the desktop icon and CLI build.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ Add the input:
 }
 ```
 
+`inputs.nixpkgs.follows` above is optional and affects only this flake's dev
+shell, formatter, and checks. The packages (`logseq`, `logseq-cli`) build against
+a separate pinned nixpkgs (`nixpkgs-pinned`) that you do not override, so they are
+served from the Cachix cache instead of rebuilt locally. Overriding `nixpkgs` no
+longer triggers a local OCaml/Melange (opam-nix) rebuild.
+
 Use the packages directly from a module where `inputs` and `pkgs` are in scope:
 
 ```nix
@@ -123,7 +129,9 @@ nix fmt
 Note: `logseq-cli` resolves its OCaml/Melange closure through opam-nix
 import-from-derivation (IFD), so the `--no-build`/`--offline` check above still
 realizes those intermediate opam derivations during evaluation; they must
-already be built or substitutable.
+already be built or substitutable. Because the closure builds against
+`nixpkgs-pinned` (not the flake's overridable `nixpkgs`), the CI-pushed opam
+derivations stay substitutable for consumers regardless of their own nixpkgs.
 
 The Darwin desktop package is validated by the `validate-aarch64-darwin`
 workflow job, which builds the package on macOS, verifies the app signature, and

--- a/flake.lock
+++ b/flake.lock
@@ -167,6 +167,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-pinned": {
+      "locked": {
+        "lastModified": 1783776592,
+        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-python38": {
       "locked": {
         "lastModified": 1708815994,
@@ -205,7 +221,7 @@
         "flake-utils": "flake-utils",
         "mirage-opam-overlays": "mirage-opam-overlays",
         "nixpkgs": [
-          "nixpkgs"
+          "nixpkgs-pinned"
         ],
         "nixpkgs-llvm17": "nixpkgs-llvm17",
         "nixpkgs-python38": "nixpkgs-python38",
@@ -290,6 +306,7 @@
         "git-hooks": "git-hooks",
         "import-tree": "import-tree",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-pinned": "nixpkgs-pinned",
         "opam-nix": "opam-nix",
         "opam-repository": "opam-repository"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,16 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    # Dedicated nixpkgs for building the packages (desktop + OCaml/Melange CLI),
+    # kept separate from `nixpkgs` so a consumer who overrides this flake's
+    # `nixpkgs` (e.g. `inputs.<this>.inputs.nixpkgs.follows` for dedup) cannot
+    # re-hash the package closure and miss the Cachix cache. The opam-nix closure
+    # is nixpkgs-dependent: building it against a consumer's nixpkgs forces a full
+    # local opam-nix `resolve` (import-from-derivation) instead of substituting
+    # the prebuilt paths. Packages and the opam toolchain follow this input; only
+    # the dev shell, formatter, and check runners use `nixpkgs`. Consumers do not
+    # override this input, so they inherit the exact rev CI built and pushed.
+    nixpkgs-pinned.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
     import-tree.url = "github:denful/import-tree";
     git-hooks = {
@@ -19,7 +29,9 @@
     # explicit flake.lock bump.
     opam-nix = {
       url = "github:tweag/opam-nix";
-      inputs.nixpkgs.follows = "nixpkgs";
+      # Follow nixpkgs-pinned (not nixpkgs) so the resolved OCaml closure stays on
+      # the CI-built rev even when a consumer overrides this flake's nixpkgs.
+      inputs.nixpkgs.follows = "nixpkgs-pinned";
       inputs.opam-repository.follows = "opam-repository";
     };
     opam-repository = {

--- a/modules/logseq-scope.nix
+++ b/modules/logseq-scope.nix
@@ -3,15 +3,27 @@
   perSystem =
     {
       lib,
-      pkgs,
       system,
       ...
     }:
+    let
+      # Build every package against nixpkgs-pinned, a separate input consumers do
+      # not override. This keeps the nixpkgs-dependent opam-nix/Melange closure on
+      # the rev CI built and pushed to Cachix, so a consumer's `nixpkgs` override
+      # (dedup) can no longer re-hash the packages and force a local opam-nix
+      # `resolve`. The flake's overridable `pkgs` still drives the dev shell,
+      # formatter, and check runners.
+      pkgsPinned = inputs.nixpkgs-pinned.legacyPackages.${system};
+    in
     {
-      _module.args.logseqNightly = import ./_packages/logseq-nightly.nix {
-        inherit lib pkgs system;
-        manifestPath = ../data/logseq-nightly.json;
-        opamNix = inputs.opam-nix;
+      _module.args = {
+        inherit pkgsPinned;
+        logseqNightly = import ./_packages/logseq-nightly.nix {
+          inherit lib system;
+          pkgs = pkgsPinned;
+          manifestPath = ../data/logseq-nightly.json;
+          opamNix = inputs.opam-nix;
+        };
       };
     };
 }

--- a/modules/packages.nix
+++ b/modules/packages.nix
@@ -1,12 +1,12 @@
 { self, ... }:
 {
   perSystem =
-    { pkgs, logseqNightly, ... }:
+    { pkgsPinned, logseqNightly, ... }:
     {
       packages = {
         logseq = logseqNightly.logseqDesktop;
         logseq-cli = logseqNightly.cli;
-        default = pkgs.symlinkJoin {
+        default = pkgsPinned.symlinkJoin {
           name = "logseq-nightly";
           paths = [
             logseqNightly.logseqDesktop


### PR DESCRIPTION
## Summary

`opam-nix` and every package build followed the flake's overridable `nixpkgs`. When a consumer sets
`inputs.nix-logseq-git-flake.inputs.nixpkgs.follows = "nixpkgs"` (the usual input-dedup pattern), the entire
OCaml/Melange closure was re-hashed against the consumer's nixpkgs rev, missing `nix-logseq-git-flake.cachix.org`
and forcing a local opam-nix `resolve` (import-from-derivation). A downstream NixOS `switch` stalled 5+ hours in
that eval-time resolve.

This adds a dedicated `nixpkgs-pinned` input and builds the package set (`logseqNightly`, the `default` symlinkJoin)
and the opam-nix toolchain from it. The overridable `nixpkgs` now drives only the dev shell, formatter, and check
runners. Consumers do not override `nixpkgs-pinned`, so they inherit the exact rev CI built and pushed regardless of
their own nixpkgs. `nixpkgs-pinned` keeps a mutable `nixos-unstable` original (the nightly `nix flake update` still
floats it) and is locked to the current `nixpkgs` rev so this change is cache-neutral.

Docs: README notes that overriding `nixpkgs` is now safe; AGENTS.md records the decoupling and warns against pointing
package builds back at the overridable `pkgs`.

## Test plan

- `nix eval packages.x86_64-linux.{logseq-cli,logseq}.drvPath` identical with and without
  `--override-input nixpkgs github:NixOS/nixpkgs/e2587cae` (immune to a consumer nixpkgs override)
- both drvPaths byte-identical to the pre-change build (no cache churn)
- `nix run .#formatter` (0 changed), `deadnix --fail`, `statix check` all clean
- x86_64 wiring: `packages.default` and `checks.x86_64-linux.logseq-cli` evaluate

Cross-system (aarch64-linux, aarch64-darwin) is structurally identical and covered by the existing native-runner CI
(the opam IFD cannot be realized locally on x86_64).
