### PR TITLE
fix(manifest): re-resolve cliCljDepsHash for git 2.55.0

### DIFF
--- a/data/logseq-nightly.json
+++ b/data/logseq-nightly.json
@@ -34,7 +34,7 @@
   ],
   "cliPnpmDepsHash": "sha256-vkR6AbgdYA3GFZ54/CtcWwMIx9LBTMaadEpzMn9vgiQ=",
   "cliBundlePnpmDepsHash": "sha256-i5zJ+lvhcBF1CA1hFY4SlEg4p6IEfFrNPYTEYiFviiE=",
-  "cliCljDepsHash": "sha256-jvky4YiP2BWVqvp2lLEyDls5zhKTThgq46Um4os+ALM=",
+  "cliCljDepsHash": "sha256-YI17pxlKGBZFQL4ScoUEv6bqff801XknWDN5P6hDsNs=",
   "cliVersion": "2.0.1-alpha+nightly.20260712",
   "toolchain": {
     "node": "24",


### PR DESCRIPTION
## What

Re-resolves `cliCljDepsHash` in `data/logseq-nightly.json` against the current `flake.lock`.

## Why

`fbff477` (`chore(flake): update inputs`) bumped nixpkgs `e7a3ca8` -> `0e251e2`, which moved:

| package | before | after |
| --- | --- | --- |
| `git` | 2.54.0 | 2.55.0 |
| `clojure` | 1.12.5.1654 | 1.12.5.1664 |

`modules/_packages/logseq-cli/clj-deps.nix` explodes the tools.gitlibs `_repos` packs into loose objects with
`git unpack-objects`, so the FOD's output bytes track the `git` build. The recorded hash still described the
2.54.0 output, so every `logseq-cli` build failed at the FOD-seeding step:

```
error: hash mismatch in fixed-output derivation
'/nix/store/398x9ax3ic72zvsh7cy9f6kc1kcr9wf6-logseq-cli-clj-deps.drv':
         specified: sha256-jvky4YiP2BWVqvp2lLEyDls5zhKTThgq46Um4os+ALM=
            got:    sha256-YI17pxlKGBZFQL4ScoUEv6bqff801XknWDN5P6hDsNs=
```

This is the failure mode `AGENTS.md` already documents under "What To Run After Common Changes -> `flake.lock`".
`fbff477` landed directly on `main` without the documented `nix build .#checks.x86_64-linux.logseq-cli`
pre-merge check, so `main` has been red since (run 31796397163), taking PR #61 with it.

The new output is reproducible, not nondeterministic: a local x86_64-linux build and the GitHub runner
independently produced the same `got:` hash for the same `.drv`.

`cliPnpmDepsHash` and `cliBundlePnpmDepsHash` were checked too and stay valid: the `pnpm` 10.34.4 -> 10.34.5
bump left both pnpm-store FODs byte-identical.

## Validation

```
nix build path:.#logseq-cli.cliCljDeps path:.#logseq-cli.cliPnpmDeps path:.#logseq-cli.cliBundlePnpmDeps   # exit 0
nix build path:.#checks.x86_64-linux.logseq-cli-help                                                        # exit 0
nix run "path:.#formatter.x86_64-linux" -- data/logseq-nightly.json                                          # 0 changed
```

The `logseq-cli-help` check builds the CLI from source (opam/Melange bundle plus the shadow-cljs db-worker)
and runs `doctor` with the db-worker spawn probe.
